### PR TITLE
Add keyboard shortcuts and up-navigation prompts

### DIFF
--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -725,6 +725,13 @@ namespace InvoiceApp.ViewModels
             {
                 SelectedInvoice = Invoices[index - 1];
             }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új számlát szeretnél létrehozni?", "Megerősítés"))
+                {
+                    NewInvoiceCommand.Execute(null);
+                }
+            }
         }
 
         /// <summary>
@@ -803,6 +810,13 @@ namespace InvoiceApp.ViewModels
             if (index > 0)
             {
                 SelectedItem = Items[index - 1];
+            }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új tételt szeretnél létrehozni?", "Megerősítés"))
+                {
+                    AddItemCommand.Execute(null);
+                }
             }
         }
 

--- a/ViewModels/PaymentMethodViewModel.cs
+++ b/ViewModels/PaymentMethodViewModel.cs
@@ -81,5 +81,28 @@ namespace InvoiceApp.ViewModels
                 await _service.SaveAsync(SelectedMethod);
             }
         }
+
+        public void SelectPreviousMethod()
+        {
+            if (SelectedMethod == null)
+            {
+                if (Methods.Count > 0)
+                    SelectedMethod = Methods[0];
+                return;
+            }
+
+            var index = Methods.IndexOf(SelectedMethod);
+            if (index > 0)
+            {
+                SelectedMethod = Methods[index - 1];
+            }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új fizetési módot szeretnél létrehozni?", "Megerősítés"))
+                {
+                    AddCommand.Execute(null);
+                }
+            }
+        }
     }
 }

--- a/ViewModels/ProductGroupViewModel.cs
+++ b/ViewModels/ProductGroupViewModel.cs
@@ -81,5 +81,28 @@ namespace InvoiceApp.ViewModels
                 await _service.SaveAsync(SelectedGroup);
             }
         }
+
+        public void SelectPreviousGroup()
+        {
+            if (SelectedGroup == null)
+            {
+                if (Groups.Count > 0)
+                    SelectedGroup = Groups[0];
+                return;
+            }
+
+            var index = Groups.IndexOf(SelectedGroup);
+            if (index > 0)
+            {
+                SelectedGroup = Groups[index - 1];
+            }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új termékcsoportot szeretnél létrehozni?", "Megerősítés"))
+                {
+                    AddCommand.Execute(null);
+                }
+            }
+        }
     }
 }

--- a/ViewModels/ProductViewModel.cs
+++ b/ViewModels/ProductViewModel.cs
@@ -198,5 +198,28 @@ namespace InvoiceApp.ViewModels
                 await _service.SaveAsync(SelectedProduct);
             }
         }
+
+        public void SelectPreviousProduct()
+        {
+            if (SelectedProduct == null)
+            {
+                if (Products.Count > 0)
+                    SelectedProduct = Products[0];
+                return;
+            }
+
+            var index = Products.IndexOf(SelectedProduct);
+            if (index > 0)
+            {
+                SelectedProduct = Products[index - 1];
+            }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új terméket szeretnél létrehozni?", "Megerősítés"))
+                {
+                    AddCommand.Execute(null);
+                }
+            }
+        }
     }
 }

--- a/ViewModels/SupplierViewModel.cs
+++ b/ViewModels/SupplierViewModel.cs
@@ -87,5 +87,28 @@ namespace InvoiceApp.ViewModels
                 await _service.SaveAsync(SelectedSupplier);
             }
         }
+
+        public void SelectPreviousSupplier()
+        {
+            if (SelectedSupplier == null)
+            {
+                if (Suppliers.Count > 0)
+                    SelectedSupplier = Suppliers[0];
+                return;
+            }
+
+            var index = Suppliers.IndexOf(SelectedSupplier);
+            if (index > 0)
+            {
+                SelectedSupplier = Suppliers[index - 1];
+            }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új szállítót szeretnél létrehozni?", "Megerősítés"))
+                {
+                    AddCommand.Execute(null);
+                }
+            }
+        }
     }
 }

--- a/ViewModels/TaxRateViewModel.cs
+++ b/ViewModels/TaxRateViewModel.cs
@@ -81,5 +81,28 @@ namespace InvoiceApp.ViewModels
                 await _service.SaveAsync(SelectedRate);
             }
         }
+
+        public void SelectPreviousRate()
+        {
+            if (SelectedRate == null)
+            {
+                if (Rates.Count > 0)
+                    SelectedRate = Rates[0];
+                return;
+            }
+
+            var index = Rates.IndexOf(SelectedRate);
+            if (index > 0)
+            {
+                SelectedRate = Rates[index - 1];
+            }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új áfakulcsot szeretnél létrehozni?", "Megerősítés"))
+                {
+                    AddCommand.Execute(null);
+                }
+            }
+        }
     }
 }

--- a/ViewModels/UnitViewModel.cs
+++ b/ViewModels/UnitViewModel.cs
@@ -81,5 +81,28 @@ namespace InvoiceApp.ViewModels
                 await _service.SaveAsync(SelectedUnit);
             }
         }
+
+        public void SelectPreviousUnit()
+        {
+            if (SelectedUnit == null)
+            {
+                if (Units.Count > 0)
+                    SelectedUnit = Units[0];
+                return;
+            }
+
+            var index = Units.IndexOf(SelectedUnit);
+            if (index > 0)
+            {
+                SelectedUnit = Units[index - 1];
+            }
+            else if (index == 0)
+            {
+                if (DialogHelper.ShowConfirmation("Új mértékegységet szeretnél létrehozni?", "Megerősítés"))
+                {
+                    AddCommand.Execute(null);
+                }
+            }
+        }
     }
 }

--- a/Views/InvoiceItemDataGrid.xaml
+++ b/Views/InvoiceItemDataGrid.xaml
@@ -20,6 +20,8 @@
             <KeyBinding Key="Up" Command="{Binding ItemsUpCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <KeyBinding Key="Down" Command="{Binding ItemsDownCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <KeyBinding Key="Escape" Command="{Binding ItemsEscapeCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
+            <KeyBinding Key="Insert" Command="{Binding InvoiceViewModel.AddItemCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
+            <KeyBinding Key="Delete" Command="{Binding InvoiceViewModel.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding SelectedItem}"/>
         </DataGrid.InputBindings>
         <DataGrid.Columns>
             <DataGridTemplateColumn Header="Termék" Width="2*">

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -174,6 +174,7 @@
         <KeyBinding Key="Enter" Command="{Binding EnterCommand}"/>
         <KeyBinding Key="Escape" Command="{Binding BackCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteInvoiceCommand}"/>
+        <KeyBinding Key="Insert" Command="{Binding InvoiceViewModel.NewInvoiceCommand}"/>
         <KeyBinding Key="F1" Command="{Binding ShowDashboardCommand}"/>
         <KeyBinding Key="F2" Command="{Binding ShowInvoiceListCommand}"/>
         <KeyBinding Key="F4" Command="{Binding ShowProductsCommand}"/>

--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -6,6 +6,10 @@
              xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
+    </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/Views/ProductGroupView.xaml
+++ b/Views/ProductGroupView.xaml
@@ -6,6 +6,10 @@
              xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
+    </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -6,6 +6,10 @@
              xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
+    </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/Views/SupplierView.xaml
+++ b/Views/SupplierView.xaml
@@ -6,6 +6,10 @@
              xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
+    </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/Views/TaxRateView.xaml
+++ b/Views/TaxRateView.xaml
@@ -6,6 +6,10 @@
              xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
+    </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/Views/UnitView.xaml
+++ b/Views/UnitView.xaml
@@ -6,6 +6,10 @@
              xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
+    </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />


### PR DESCRIPTION
## Summary
- bind Insert to create new invoice
- allow inserting/deleting invoice items via keyboard
- map Insert/Delete keys in catalog views
- prompt for new entries when pressing Up at start of lists

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68791a0dc7008322b1baadfbc9817436