### PR TITLE
Handle Enter key for invoice header navigation

### DIFF
--- a/Views/InvoiceHeaderView.xaml
+++ b/Views/InvoiceHeaderView.xaml
@@ -4,9 +4,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             mc:Ignorable="d"
-            d:DesignHeight="120" d:DesignWidth="400">
+            d:DesignHeight="120" d:DesignWidth="400"
+            KeyDown="HeaderView_KeyDown">
     <UserControl.InputBindings>
-        <KeyBinding Key="Enter" Command="{Binding HeaderEnterCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
         <KeyBinding Key="Escape" Command="{Binding HeaderEscapeCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
         <KeyBinding Key="Up" Command="{Binding HeaderUpCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
         <KeyBinding Key="Down" Command="{Binding HeaderDownCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>

--- a/Views/InvoiceHeaderView.xaml.cs
+++ b/Views/InvoiceHeaderView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using InvoiceApp.ViewModels;
 
 namespace InvoiceApp.Views
@@ -16,6 +17,26 @@ namespace InvoiceApp.Views
             if (DataContext is InvoiceViewModel vm && sender is ComboBox combo)
             {
                 vm.EnsureSupplierExists(combo.Text);
+            }
+        }
+
+        private void HeaderView_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                var element = Keyboard.FocusedElement as UIElement;
+                bool isLast = element is CheckBox;
+                element?.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+
+                if (isLast)
+                {
+                    if (Window.GetWindow(this)?.DataContext is MainViewModel vm)
+                    {
+                        vm.HeaderEnterCommand.Execute(null);
+                    }
+                }
+
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- move Enter handling from XAML keybinding to code-behind
- implement `HeaderView_KeyDown` for focus traversal and command execution

## Testing
- `dotnet build --no-restore` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_687926d8bde88322b9c1ff48fc410a9a