### PR TITLE
Add ConfirmDialogViewModel and bind commands

### DIFF
--- a/ViewModels/ConfirmDialogViewModel.cs
+++ b/ViewModels/ConfirmDialogViewModel.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace InvoiceApp.ViewModels
+{
+    public class ConfirmDialogViewModel : ViewModelBase
+    {
+        private string _message;
+        public string Message
+        {
+            get => _message;
+            set { _message = value; OnPropertyChanged(); }
+        }
+
+        public RelayCommand YesCommand { get; }
+        public RelayCommand NoCommand { get; }
+
+        public ConfirmDialogViewModel(string message, Action<bool?> closeAction)
+        {
+            _message = message;
+            YesCommand = new RelayCommand(_ => closeAction(true));
+            NoCommand = new RelayCommand(_ => closeAction(false));
+        }
+    }
+}

--- a/Views/ConfirmDialog.xaml
+++ b/Views/ConfirmDialog.xaml
@@ -6,15 +6,19 @@
         MinHeight="150" MinWidth="350"
         WindowStartupLocation="CenterOwner"
         WindowStyle="ToolWindow" ResizeMode="NoResize"
-        KeyDown="Window_KeyDown"
         FocusManager.FocusedElement="{Binding ElementName=YesButton}">
+    <Window.InputBindings>
+        <KeyBinding Key="Enter" Command="{Binding YesCommand}"/>
+        <KeyBinding Key="Escape" Command="{Binding NoCommand}"/>
+    </Window.InputBindings>
     <StackPanel Margin="10">
-        <TextBlock x:Name="MessageText" TextWrapping="Wrap" Margin="0,0,0,10" />
+        <TextBlock Text="{Binding Message}" TextWrapping="Wrap" Margin="0,0,0,10" />
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button x:Name="YesButton" Content="Igen" Width="75" Margin="5,0" Click="Yes_Click"
-                    helpers:FocusBehavior.IsFocused="True" IsDefault="True"/>
+            <Button x:Name="YesButton" Content="Igen" Width="75" Margin="5,0"
+                    helpers:FocusBehavior.IsFocused="True" IsDefault="True"
+                    Command="{Binding YesCommand}"/>
             <Button x:Name="NoButton" Content="Nem" Width="75" Margin="5,0"
-                    IsCancel="True" Click="No_Click"/>
+                    IsCancel="True" Command="{Binding NoCommand}"/>
         </StackPanel>
     </StackPanel>
 </Window>

--- a/Views/ConfirmDialog.xaml.cs
+++ b/Views/ConfirmDialog.xaml.cs
@@ -1,46 +1,27 @@
 using System.Windows;
-using System.Windows.Input;
+using InvoiceApp.ViewModels;
 
 namespace InvoiceApp.Views
 {
     public partial class ConfirmDialog : Window
     {
+        public ConfirmDialogViewModel ViewModel { get; }
+
         public ConfirmDialog()
         {
             InitializeComponent();
+            ViewModel = new ConfirmDialogViewModel(string.Empty, SetResult);
+            DataContext = ViewModel;
         }
 
         public ConfirmDialog(string message) : this()
         {
-            Message = message;
+            ViewModel.Message = message;
         }
 
-        public string Message
+        private void SetResult(bool? result)
         {
-            get => MessageText.Text;
-            set => MessageText.Text = value;
-        }
-
-        private void Yes_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = true;
-        }
-
-        private void No_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-        }
-
-        private void Window_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Enter)
-            {
-                DialogResult = true;
-            }
-            else if (e.Key == Key.Escape)
-            {
-                DialogResult = false;
-            }
+            DialogResult = result;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ConfirmDialogViewModel` with Yes/No commands
- bind ConfirmDialog buttons to commands
- set dialog DataContext to the new ViewModel

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879569bd918832298c8dfe93bcbbc22