### PR TITLE
Add global DataGrid style

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -29,5 +29,18 @@
             <Setter Property="Padding" Value="8,4"/>
             <Setter Property="Margin" Value="4"/>
         </Style>
+        <Style TargetType="DataGrid">
+            <Setter Property="ColumnWidth" Value="*"/>
+            <Setter Property="RowBackground" Value="White"/>
+            <Setter Property="AlternatingRowBackground" Value="LightGray"/>
+            <Setter Property="SelectionUnit" Value="FullRow"/>
+            <Setter Property="RowStyle">
+                <Setter.Value>
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="SelectedBackground" Value="LightBlue"/>
+                    </Style>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Application.Resources>
 </Application>

--- a/Views/InvoiceItemDataGrid.xaml
+++ b/Views/InvoiceItemDataGrid.xaml
@@ -24,7 +24,7 @@
             <KeyBinding Key="Delete" Command="{Binding InvoiceViewModel.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding SelectedItem}"/>
         </DataGrid.InputBindings>
         <DataGrid.Columns>
-            <DataGridTemplateColumn Header="Termék" Width="2*">
+            <DataGridTemplateColumn Header="Termék">
                 <DataGridTemplateColumn.CellTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Item.Product.Name}" />
@@ -40,16 +40,13 @@
             </DataGridTemplateColumn>
             <DataGridTextColumn Header="Mennyiség"
                                Binding="{Binding Quantity, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}}"
-                               Width="Auto"
                                ElementStyle="{StaticResource RightAlignedCellStyle}"/>
             <DataGridTextColumn Header="Egység"
-                               Binding="{Binding Item.Product.Unit.Code}"
-                               Width="Auto"/>
+                               Binding="{Binding Item.Product.Unit.Code}"/>
             <DataGridTextColumn Header="Ár"
                                Binding="{Binding UnitPrice, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}}"
-                               Width="Auto"
                                ElementStyle="{StaticResource RightAlignedCellStyle}"/>
-            <DataGridTemplateColumn Header="ÁFA %" Width="Auto">
+            <DataGridTemplateColumn Header="ÁFA %">
                 <DataGridTemplateColumn.CellTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding TaxRatePercentage}" />
@@ -68,14 +65,12 @@
             <DataGridTextColumn Header="Nettó érték"
                                Binding="{Binding NetAmount, StringFormat={}{0:F2}}"
                                IsReadOnly="True"
-                               Width="Auto"
                                ElementStyle="{StaticResource RightAlignedCellStyle}"/>
             <DataGridTextColumn Header="Bruttó érték"
                                Binding="{Binding GrossAmount, StringFormat={}{0:F2}}"
                                IsReadOnly="True"
-                               Width="Auto"
                                ElementStyle="{StaticResource RightAlignedCellStyle}"/>
-            <DataGridTemplateColumn Header="" Width="Auto">
+            <DataGridTemplateColumn Header="">
                 <DataGridTemplateColumn.CellTemplate>
                     <DataTemplate>
                         <Button Content="💾"

--- a/Views/InvoiceListView.xaml
+++ b/Views/InvoiceListView.xaml
@@ -16,12 +16,11 @@
                   CanUserAddRows="False"
                   Margin="5">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Szám" Binding="{Binding Number}" Width="Auto" />
-                <DataGridTextColumn Header="Dátum" Binding="{Binding Date, StringFormat=d}" Width="Auto" />
-                <DataGridTextColumn Header="Szállító" Binding="{Binding Supplier.Name}" Width="*" />
+                <DataGridTextColumn Header="Szám" Binding="{Binding Number}" />
+                <DataGridTextColumn Header="Dátum" Binding="{Binding Date, StringFormat=d}" />
+                <DataGridTextColumn Header="Szállító" Binding="{Binding Supplier.Name}" />
                 <DataGridTextColumn Header="Összeg"
                                       Binding="{Binding Amount, StringFormat={}{0:F2}}"
-                                      Width="Auto"
                                       ElementStyle="{StaticResource RightAlignedCellStyle}" />
             </DataGrid.Columns>
         </DataGrid>

--- a/Views/InvoiceSummaryPanel.xaml
+++ b/Views/InvoiceSummaryPanel.xaml
@@ -24,19 +24,15 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ÁFA %"
                                             Binding="{Binding Rate, StringFormat={}{0:F2}}"
-                                            Width="Auto"
                                             ElementStyle="{StaticResource RightAlignedCellStyle}"/>
                         <DataGridTextColumn Header="Nettó összeg"
                                             Binding="{Binding Net, StringFormat={}{0:F2}}"
-                                            Width="*"
                                             ElementStyle="{StaticResource RightAlignedCellStyle}"/>
                         <DataGridTextColumn Header="ÁFA összeg"
                                             Binding="{Binding Vat, StringFormat={}{0:F2}}"
-                                            Width="*"
                                             ElementStyle="{StaticResource RightAlignedCellStyle}"/>
                         <DataGridTextColumn Header="Bruttó összeg"
                                             Binding="{Binding Gross, StringFormat={}{0:F2}}"
-                                            Width="*"
                                             ElementStyle="{StaticResource RightAlignedCellStyle}"/>
                     </DataGrid.Columns>
                 </DataGrid>

--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -22,10 +22,9 @@
                   CanUserAddRows="False"
                   Margin="5">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
                 <DataGridTextColumn Header="Határidő"
                                       Binding="{Binding DueInDays, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}}"
-                                      Width="Auto"
                                       ElementStyle="{StaticResource RightAlignedCellStyle}" />
             </DataGrid.Columns>
         </DataGrid>

--- a/Views/ProductGroupView.xaml
+++ b/Views/ProductGroupView.xaml
@@ -22,7 +22,7 @@
                   CanUserAddRows="False"
                   Margin="5">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -34,16 +34,16 @@
                   Margin="5"
                   PreviewKeyDown="DataGrid_OnPreviewKeyDown">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" Width="Auto" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" />
                 <DataGridTextColumn Header="Nettó"
                                     Binding="{Binding Net, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}, ValidatesOnNotifyDataErrors=True}"
-                                    Width="Auto"
+
                                     ElementStyle="{StaticResource RightAlignedCellStyle}" />
                 <DataGridTextColumn Header="Bruttó"
                                     Binding="{Binding Gross, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}, ValidatesOnNotifyDataErrors=True}"
-                                    Width="Auto"
+
                                     ElementStyle="{StaticResource RightAlignedCellStyle}" />
-                <DataGridTemplateColumn Header="ÁFA %" Width="Auto">
+                <DataGridTemplateColumn Header="ÁFA %">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding TaxRate.Percentage}" />
@@ -59,7 +59,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Egység" Width="Auto">
+                <DataGridTemplateColumn Header="Egység">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding Unit.Code}" />
@@ -73,7 +73,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Csoport" Width="Auto">
+                <DataGridTemplateColumn Header="Csoport">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding ProductGroup.Name}" />

--- a/Views/SupplierView.xaml
+++ b/Views/SupplierView.xaml
@@ -22,9 +22,9 @@
                   CanUserAddRows="False"
                   Margin="5">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
-                <DataGridTextColumn Header="Adószám" Binding="{Binding TaxId, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
-                <DataGridTextColumn Header="Bankszámla" Binding="{Binding BankAccntNr, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
+                <DataGridTextColumn Header="Adószám" Binding="{Binding TaxId, UpdateSourceTrigger=PropertyChanged}" />
+                <DataGridTextColumn Header="Bankszámla" Binding="{Binding BankAccntNr, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">

--- a/Views/TaxRateView.xaml
+++ b/Views/TaxRateView.xaml
@@ -22,13 +22,13 @@
                   CanUserAddRows="False"
                   Margin="5">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
                 <DataGridTextColumn Header="%"
                                     Binding="{Binding Percentage, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}}"
-                                    Width="Auto"
+
                                     ElementStyle="{StaticResource RightAlignedCellStyle}" />
-                <DataGridTextColumn Header="Kezdete" Binding="{Binding EffectiveFrom, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
-                <DataGridTextColumn Header="Vége" Binding="{Binding EffectiveTo, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
+                <DataGridTextColumn Header="Kezdete" Binding="{Binding EffectiveFrom, UpdateSourceTrigger=PropertyChanged}" />
+                <DataGridTextColumn Header="Vége" Binding="{Binding EffectiveTo, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">

--- a/Views/UnitView.xaml
+++ b/Views/UnitView.xaml
@@ -22,8 +22,8 @@
                   CanUserAddRows="False"
                   Margin="5">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Kód" Binding="{Binding Code, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
-                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
+                <DataGridTextColumn Header="Kód" Binding="{Binding Code, UpdateSourceTrigger=PropertyChanged}" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">


### PR DESCRIPTION
## Summary
- add a default `DataGrid` style in `App.xaml` for column widths, row colors and selection
- remove explicit column width settings from all DataGrid views

## Testing
- `xmllint --noout` on all modified XAML files

------
https://chatgpt.com/codex/tasks/task_e_687957c1a1c883228c12e1042447b8ea