### PR TITLE
Add dirty-tracking to Product and Supplier views

### DIFF
--- a/ViewModels/ProductViewModel.cs
+++ b/ViewModels/ProductViewModel.cs
@@ -24,6 +24,7 @@ namespace InvoiceApp.ViewModels
         private ICollectionView? _productsView;
         private Product? _selectedProduct;
         private string _searchText = string.Empty;
+        private bool _hasChanges;
 
         public ObservableCollection<Product> Products
         {
@@ -78,6 +79,24 @@ namespace InvoiceApp.ViewModels
             }
         }
 
+        public bool HasChanges
+        {
+            get => _hasChanges;
+            private set { _hasChanges = value; OnPropertyChanged(); }
+        }
+
+        public void MarkDirty()
+        {
+            HasChanges = true;
+            SaveCommand.RaiseCanExecuteChanged();
+        }
+
+        public void ClearChanges()
+        {
+            HasChanges = false;
+            SaveCommand.RaiseCanExecuteChanged();
+        }
+
         public RelayCommand AddCommand { get; }
         public RelayCommand DeleteCommand { get; }
         public RelayCommand SaveCommand { get; }
@@ -103,8 +122,11 @@ namespace InvoiceApp.ViewModels
             SaveCommand = new RelayCommand(async _ =>
             {
                 await SaveSelectedAsync();
+                ClearChanges();
                 DialogHelper.ShowInfo("Mentés kész.");
             }, _ => SelectedProduct != null && !string.IsNullOrWhiteSpace(SelectedProduct?.Name));
+
+            ClearChanges();
         }
 
         public async Task LoadAsync()
@@ -155,12 +177,14 @@ namespace InvoiceApp.ViewModels
             }
             Products.Add(product);
             SelectedProduct = product;
+            MarkDirty();
         }
 
         private async Task DeleteProductAsync(Product product)
         {
             await _service.DeleteAsync(product.Id);
             Products.Remove(product);
+            MarkDirty();
         }
 
         private async Task SaveSelectedAsync()

--- a/ViewModels/SupplierViewModel.cs
+++ b/ViewModels/SupplierViewModel.cs
@@ -13,6 +13,7 @@ namespace InvoiceApp.ViewModels
         private readonly ISupplierService _service;
         private ObservableCollection<Supplier> _suppliers = new();
         private Supplier? _selectedSupplier;
+        private bool _hasChanges;
 
         public ObservableCollection<Supplier> Suppliers
         {
@@ -30,6 +31,24 @@ namespace InvoiceApp.ViewModels
                 DeleteCommand.RaiseCanExecuteChanged();
                 SaveCommand.RaiseCanExecuteChanged();
             }
+        }
+
+        public bool HasChanges
+        {
+            get => _hasChanges;
+            private set { _hasChanges = value; OnPropertyChanged(); }
+        }
+
+        public void MarkDirty()
+        {
+            HasChanges = true;
+            SaveCommand.RaiseCanExecuteChanged();
+        }
+
+        public void ClearChanges()
+        {
+            HasChanges = false;
+            SaveCommand.RaiseCanExecuteChanged();
         }
 
         public RelayCommand AddCommand { get; }
@@ -51,8 +70,11 @@ namespace InvoiceApp.ViewModels
             SaveCommand = new RelayCommand(async _ =>
             {
                 await SaveSelectedAsync();
+                ClearChanges();
                 DialogHelper.ShowInfo("Mentés kész.");
             }, _ => SelectedSupplier != null && !string.IsNullOrWhiteSpace(SelectedSupplier?.Name));
+
+            ClearChanges();
         }
 
         public async Task LoadAsync()
@@ -71,6 +93,7 @@ namespace InvoiceApp.ViewModels
             };
             Suppliers.Add(supplier);
             SelectedSupplier = supplier;
+            MarkDirty();
             return supplier;
         }
 
@@ -78,6 +101,7 @@ namespace InvoiceApp.ViewModels
         {
             await _service.DeleteAsync(supplier.Id);
             Suppliers.Remove(supplier);
+            MarkDirty();
         }
 
         private async Task SaveSelectedAsync()

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -32,7 +32,8 @@
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
                   Margin="5"
-                  PreviewKeyDown="DataGrid_OnPreviewKeyDown">
+                  PreviewKeyDown="DataGrid_OnPreviewKeyDown"
+                  CellEditEnding="DataGrid_CellEditEnding">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
                 <DataGridTextColumn Header="Nettó"

--- a/Views/ProductView.xaml.cs
+++ b/Views/ProductView.xaml.cs
@@ -47,6 +47,11 @@ namespace InvoiceApp.Views
             e.Handled = true;
         }
 
+        private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+        {
+            _viewModel.MarkDirty();
+        }
+
         private static T? FindParent<T>(DependencyObject? child) where T : DependencyObject
         {
             while (child != null && child is not T)

--- a/Views/SupplierView.xaml
+++ b/Views/SupplierView.xaml
@@ -20,7 +20,8 @@
                   SelectedItem="{Binding SelectedSupplier}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
-                  Margin="5">
+                  Margin="5"
+                  CellEditEnding="DataGrid_CellEditEnding">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
                 <DataGridTextColumn Header="Adószám" Binding="{Binding TaxId, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />

--- a/Views/SupplierView.xaml.cs
+++ b/Views/SupplierView.xaml.cs
@@ -16,5 +16,10 @@ namespace InvoiceApp.Views
             DataContext = _viewModel;
             Loaded += async (s, e) => await _viewModel.LoadAsync();
         }
+
+        private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+        {
+            _viewModel.MarkDirty();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- track changes in ProductViewModel and SupplierViewModel
- update xaml views to signal cell editing completion
- raise Save command on dirty state changes

## Testing
- `dotnet build --no-restore` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68793f582d508322b400050d2bcc8b19