### PR TITLE
Display AppState in status bar

### DIFF
--- a/Models/AppState.cs
+++ b/Models/AppState.cs
@@ -97,5 +97,30 @@ namespace InvoiceApp.Models
             AppState.ConfirmDialog => typeof(ConfirmDialog),
             _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
         };
+
+        /// <summary>
+        /// Gets a human readable description for the specified
+        /// <see cref="AppState"/> in Hungarian.
+        /// </summary>
+        /// <param name="state">The application state.</param>
+        /// <returns>The descriptive label.</returns>
+        public static string GetDescription(this AppState state) => state switch
+        {
+            AppState.MainWindow => "F\u0151ablak",
+            AppState.Dashboard => "Vez\u00e9rl\u0151pult",
+            AppState.InvoiceList => "Sz\u00e1ml\u00e1k",
+            AppState.InvoiceEditor => "Sz\u00e1mlaszerkeszt\u0151",
+            AppState.Header => "Fejl\u00e9c",
+            AppState.ItemList => "T\u00e9telek",
+            AppState.Summary => "\u00d6sszes\u00edt\u0151",
+            AppState.Products => "Term\u00e9kek",
+            AppState.ProductGroups => "Term\u00e9kcsoportok",
+            AppState.Suppliers => "Sz\u00e1ll\u00edt\u00f3k",
+            AppState.TaxRates => "\u00c1fakulcsok",
+            AppState.Units => "Egys\u00e9gek",
+            AppState.PaymentMethods => "Fizet\u00e9si m\u00f3dok",
+            AppState.ConfirmDialog => "Meger\u0151s\u00edt\u00e9s",
+            _ => state.ToString()
+        };
     }
 }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -12,6 +12,7 @@ namespace InvoiceApp.ViewModels
     {
         private readonly INavigationService _navigation;
         private AppState _current;
+        private string _currentStateDescription = string.Empty;
         public InvoiceViewModel InvoiceViewModel { get; }
 
         public AppState CurrentState
@@ -20,6 +21,17 @@ namespace InvoiceApp.ViewModels
             private set
             {
                 _current = value;
+                OnPropertyChanged();
+                CurrentStateDescription = value.GetDescription();
+            }
+        }
+
+        public string CurrentStateDescription
+        {
+            get => _currentStateDescription;
+            private set
+            {
+                _currentStateDescription = value;
                 OnPropertyChanged();
             }
         }
@@ -61,7 +73,8 @@ namespace InvoiceApp.ViewModels
             _navigation = navigation;
             InvoiceViewModel = invoiceViewModel;
             _current = _navigation.CurrentState;
-            _navigation.StateChanged += (_, state) => CurrentState = state;
+            _currentStateDescription = _current.GetDescription();
+            _navigation.StateChanged += OnStateChanged;
 
             BackCommand = new RelayCommand(_ => _navigation.Pop());
             NavigateUpCommand = new RelayCommand(_ => InvoiceViewModel.SelectPreviousInvoice());
@@ -133,6 +146,11 @@ namespace InvoiceApp.ViewModels
             SwitchTaxRatesCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.TaxRates));
             SwitchUnitsCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Units));
             SwitchProductsCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Products));
+        }
+
+        private void OnStateChanged(object? sender, AppState state)
+        {
+            CurrentState = state;
         }
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -125,9 +125,6 @@
                         <views:InvoiceSummaryPanel />
                     </Border>
                 </Grid>
-                <StatusBar Grid.Row="2" Grid.ColumnSpan="2">
-                    <TextBlock Text="{Binding InvoiceViewModel.StatusMessage}" />
-                </StatusBar>
             </Grid>
         </DataTemplate>
         <DataTemplate x:Key="PaymentMethodsTemplate">
@@ -200,7 +197,13 @@
         <KeyBinding Key="F7" Command="{Binding ShowTaxRatesCommand}"/>
         <KeyBinding Key="F8" Command="{Binding ShowPaymentMethodsCommand}"/>
     </Window.InputBindings>
-    <ContentControl x:Name="StateRegion"
-                    Content="{Binding CurrentState}"
-                    ContentTemplateSelector="{StaticResource StateSelector}" />
+    <DockPanel>
+        <StatusBar DockPanel.Dock="Bottom">
+            <TextBlock Text="{Binding CurrentStateDescription}" Margin="0,0,10,0"/>
+            <TextBlock Text="{Binding InvoiceViewModel.StatusMessage}" />
+        </StatusBar>
+        <ContentControl x:Name="StateRegion"
+                        Content="{Binding CurrentState}"
+                        ContentTemplateSelector="{StaticResource StateSelector}" />
+    </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- map `AppState` values to human readable names
- expose `CurrentStateDescription` on `MainViewModel`
- show current app state in `MainWindow` status bar

## Testing
- `dotnet build -clp:ErrorsOnly` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687966a40cc883229840d4d96f151a8a