### PR TITLE
Add SaveAndNew command

### DIFF
--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -295,6 +295,7 @@ namespace InvoiceApp.ViewModels
         public ICommand RemoveInvoiceCommand { get; }
         public ICommand SaveItemCommand { get; }
         public ICommand SaveCommand { get; }
+        public ICommand SaveAndNewCommand { get; }
         public ICommand NewInvoiceCommand { get; }
         public ICommand AddSupplierCommand { get; }
         public Func<InvoiceItemViewModel> NewItemCommand { get; }
@@ -347,6 +348,11 @@ namespace InvoiceApp.ViewModels
                 }
             }, obj => obj is InvoiceItemViewModel);
             SaveCommand = new RelayCommand(async _ => await SaveAsync(), _ => Validate());
+            SaveAndNewCommand = new RelayCommand(async _ =>
+            {
+                await SaveAsync();
+                await NewInvoice();
+            }, _ => Validate());
             NewInvoiceCommand = new RelayCommand(async _ => await NewInvoice());
             AddSupplierCommand = new RelayCommand(_ => AddSupplier());
             NewItemCommand = CreateItemViewModel;

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -108,6 +108,10 @@
                                 Command="{Binding InvoiceViewModel.SaveCommand}"
                                 Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Számla mentése"/>
+                        <Button Content="💾➕ Mentés és új"
+                                Command="{Binding InvoiceViewModel.SaveAndNewCommand}"
+                                Style="{StaticResource IconButtonStyle}"
+                                ToolTip="Mentés és új számla"/>
                     </StackPanel>
                     <Border Grid.Row="3">
                         <Border.Style>
@@ -189,6 +193,7 @@
         <KeyBinding Key="Escape" Command="{Binding BackCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteInvoiceCommand}"/>
         <KeyBinding Key="Insert" Command="{Binding InvoiceViewModel.NewInvoiceCommand}"/>
+        <KeyBinding Key="N" Modifiers="Control+Shift" Command="{Binding InvoiceViewModel.SaveAndNewCommand}"/>
         <KeyBinding Key="F1" Command="{Binding ShowDashboardCommand}"/>
         <KeyBinding Key="F2" Command="{Binding ShowInvoiceListCommand}"/>
         <KeyBinding Key="F4" Command="{Binding ShowProductsCommand}"/>


### PR DESCRIPTION
## Summary
- extend `InvoiceViewModel` with a `SaveAndNewCommand`
- add a button and hotkey in `MainWindow` for quick save and new

## Testing
- `dotnet` command not available in environment

------
https://chatgpt.com/codex/tasks/task_e_68796df0be5083229108b8f19b0b7579