### PR TITLE
Fix data grid preview key event wiring

### DIFF
--- a/Views/InvoiceItemDataGrid.xaml
+++ b/Views/InvoiceItemDataGrid.xaml
@@ -15,7 +15,7 @@
               AutoGenerateColumns="False"
               CanUserAddRows="True"
               RowDetailsVisibilityMode="{Binding IsRowDetailsVisible, Converter={StaticResource BoolToVisibilityConverter}}"
-              PreviewKeyDown="helpers:DataGridFocusBehavior.OnPreviewKeyDown"
+              PreviewKeyDown="DataGrid_PreviewKeyDown"
               Margin="0,0,0,4">
         <DataGrid.InputBindings>
             <KeyBinding Key="Enter" Command="{Binding ItemsEnterCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>

--- a/Views/InvoiceItemDataGrid.xaml.cs
+++ b/Views/InvoiceItemDataGrid.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows.Controls;
+using System.Windows.Input;
+using InvoiceApp.Helpers;
 
 namespace InvoiceApp.Views
 {
@@ -10,5 +12,10 @@ namespace InvoiceApp.Views
         }
 
         public DataGrid DataGrid => InnerGrid;
+
+        private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+        }
     }
 }

--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -22,7 +22,7 @@
                   SelectedItem="{Binding SelectedMethod}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
-                  PreviewKeyDown="helpers:DataGridFocusBehavior.OnPreviewKeyDown"
+                  PreviewKeyDown="DataGrid_PreviewKeyDown"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/PaymentMethodView.xaml.cs
+++ b/Views/PaymentMethodView.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows.Controls;
 using System.Windows;
+using System.Windows.Input;
+using InvoiceApp.Helpers;
 using InvoiceApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +17,11 @@ namespace InvoiceApp.Views
             _viewModel = ((App)Application.Current).Services.GetRequiredService<PaymentMethodViewModel>();
             DataContext = _viewModel;
             Loaded += async (s, e) => await _viewModel.LoadAsync();
+        }
+
+        private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
     }
 }

--- a/Views/ProductGroupView.xaml
+++ b/Views/ProductGroupView.xaml
@@ -22,7 +22,7 @@
                   SelectedItem="{Binding SelectedGroup}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
-                  PreviewKeyDown="helpers:DataGridFocusBehavior.OnPreviewKeyDown"
+                  PreviewKeyDown="DataGrid_PreviewKeyDown"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/ProductGroupView.xaml.cs
+++ b/Views/ProductGroupView.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows.Controls;
 using System.Windows;
+using System.Windows.Input;
+using InvoiceApp.Helpers;
 using InvoiceApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +17,11 @@ namespace InvoiceApp.Views
             _viewModel = ((App)Application.Current).Services.GetRequiredService<ProductGroupViewModel>();
             DataContext = _viewModel;
             Loaded += async (s, e) => await _viewModel.LoadAsync();
+        }
+
+        private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
     }
 }

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -34,7 +34,7 @@
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
                   Margin="5"
-                  PreviewKeyDown="helpers:DataGridFocusBehavior.OnPreviewKeyDown"
+                    PreviewKeyDown="DataGrid_PreviewKeyDown"
                   CellEditEnding="DataGrid_CellEditEnding">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" />

--- a/Views/ProductView.xaml.cs
+++ b/Views/ProductView.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows.Controls;
+using System.Windows;
+using System.Windows.Input;
 using InvoiceApp.Helpers;
 using InvoiceApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +22,11 @@ namespace InvoiceApp.Views
         private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
         {
             _viewModel.MarkDirty();
+        }
+
+        private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
     }
 }

--- a/Views/SupplierView.xaml
+++ b/Views/SupplierView.xaml
@@ -22,7 +22,7 @@
                   SelectedItem="{Binding SelectedSupplier}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
-                  PreviewKeyDown="helpers:DataGridFocusBehavior.OnPreviewKeyDown"
+                  PreviewKeyDown="DataGrid_PreviewKeyDown"
                   Margin="5"
                   CellEditEnding="DataGrid_CellEditEnding">
             <DataGrid.Columns>

--- a/Views/SupplierView.xaml.cs
+++ b/Views/SupplierView.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows.Controls;
 using System.Windows;
+using System.Windows.Input;
+using InvoiceApp.Helpers;
 using InvoiceApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +22,11 @@ namespace InvoiceApp.Views
         private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
         {
             _viewModel.MarkDirty();
+        }
+
+        private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
     }
 }

--- a/Views/TaxRateView.xaml
+++ b/Views/TaxRateView.xaml
@@ -22,7 +22,7 @@
                   SelectedItem="{Binding SelectedRate}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
-                  PreviewKeyDown="helpers:DataGridFocusBehavior.OnPreviewKeyDown"
+                  PreviewKeyDown="DataGrid_PreviewKeyDown"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/TaxRateView.xaml.cs
+++ b/Views/TaxRateView.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows.Controls;
 using System.Windows;
+using System.Windows.Input;
+using InvoiceApp.Helpers;
 using InvoiceApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +17,11 @@ namespace InvoiceApp.Views
             _viewModel = ((App)Application.Current).Services.GetRequiredService<TaxRateViewModel>();
             DataContext = _viewModel;
             Loaded += async (s, e) => await _viewModel.LoadAsync();
+        }
+
+        private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
     }
 }

--- a/Views/UnitView.xaml
+++ b/Views/UnitView.xaml
@@ -22,7 +22,7 @@
                   SelectedItem="{Binding SelectedUnit}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
-                  PreviewKeyDown="helpers:DataGridFocusBehavior.OnPreviewKeyDown"
+                  PreviewKeyDown="DataGrid_PreviewKeyDown"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Kód" Binding="{Binding Code, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/UnitView.xaml.cs
+++ b/Views/UnitView.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows.Controls;
 using System.Windows;
+using System.Windows.Input;
+using InvoiceApp.Helpers;
 using InvoiceApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +17,11 @@ namespace InvoiceApp.Views
             _viewModel = ((App)Application.Current).Services.GetRequiredService<UnitViewModel>();
             DataContext = _viewModel;
             Loaded += async (s, e) => await _viewModel.LoadAsync();
+        }
+
+        private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- wire DataGrid PreviewKeyDown events to local handlers
- delegate key handling to `DataGridFocusBehavior`
- add missing using directives and helper calls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687960c59e848322a686003ca1513308