### PR TITLE
Add editable placeholder row for invoice items

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -50,6 +50,9 @@
                             <Trigger Property="IsSelected" Value="True">
                                 <Setter Property="Background" Value="LightBlue"/>
                             </Trigger>
+                            <Trigger Property="IsNewItem" Value="True">
+                                <Setter Property="Background" Value="LightGoldenrodYellow"/>
+                            </Trigger>
                         </Style.Triggers>
                     </Style>
                 </Setter.Value>

--- a/Views/InvoiceItemDataGrid.xaml
+++ b/Views/InvoiceItemDataGrid.xaml
@@ -14,8 +14,11 @@
               SelectedItem="{Binding SelectedItem}"
               AutoGenerateColumns="False"
               CanUserAddRows="True"
+              NewItemPlaceholderPosition="Top"
               RowDetailsVisibilityMode="{Binding IsRowDetailsVisible, Converter={StaticResource BoolToVisibilityConverter}}"
               PreviewKeyDown="DataGrid_PreviewKeyDown"
+              InitializingNewItem="DataGrid_InitializingNewItem"
+              LoadingRow="DataGrid_LoadingRow"
               Margin="0,0,0,4">
         <DataGrid.InputBindings>
             <KeyBinding Key="Enter" Command="{Binding ItemsEnterCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>

--- a/Views/InvoiceItemDataGrid.xaml.cs
+++ b/Views/InvoiceItemDataGrid.xaml.cs
@@ -1,6 +1,8 @@
+using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Input;
 using InvoiceApp.Helpers;
+using InvoiceApp.ViewModels;
 
 namespace InvoiceApp.Views
 {
@@ -16,6 +18,36 @@ namespace InvoiceApp.Views
         private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+        }
+
+        private void DataGrid_InitializingNewItem(object sender, InitializingNewItemEventArgs e)
+        {
+            if (DataContext is InvoiceViewModel vm && e.NewItem is InvoiceItemViewModel item)
+            {
+                var product = vm.Products.FirstOrDefault();
+                var rate = vm.TaxRates.FirstOrDefault();
+
+                item.Item.InvoiceId = vm.SelectedInvoice?.Id ?? 0;
+                item.Item.Product = product;
+                item.ProductId = product?.Id ?? 0;
+                item.Item.TaxRate = rate;
+                item.TaxRateId = rate?.Id ?? 0;
+                item.TaxRatePercentage = rate?.Percentage ?? 0m;
+                item.IsGross = vm.IsGrossCalculation;
+            }
+        }
+
+        private void DataGrid_LoadingRow(object sender, DataGridRowEventArgs e)
+        {
+            if (e.Row.IsNewItem && sender is DataGrid grid)
+            {
+                grid.Dispatcher.InvokeAsync(() =>
+                {
+                    grid.SelectedItem = e.Row.Item;
+                    grid.CurrentCell = new DataGridCellInfo(e.Row.Item, grid.Columns[0]);
+                    grid.BeginEdit();
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow top placement of the `NewItemPlaceholder` in the items grid
- style placeholder rows with a yellow background
- set default values when creating new invoice items
- automatically begin editing the placeholder row

## Testing
- `dotnet build -nologo` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879767b78788322b7bc56263b26ec5d