### PR TITLE
Fix arrow key navigation when TextBox focused

### DIFF
--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -6,7 +6,8 @@
         xmlns:views="clr-namespace:InvoiceApp.Views"
         xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
         mc:Ignorable="d"
-        Title="Számlakezelő" MinHeight="600" MinWidth="1000">
+        Title="Számlakezelő" MinHeight="600" MinWidth="1000"
+        PreviewKeyDown="Window_PreviewKeyDown">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <DataTemplate x:Key="MainWindowTemplate">

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -20,5 +20,25 @@ namespace InvoiceApp.Views
                 _viewModel.InvoiceViewModel.IsInvoiceListFocused = true;
             };
         }
+
+        private void Window_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Up)
+            {
+                if (_viewModel.NavigateUpCommand.CanExecute(null))
+                {
+                    _viewModel.NavigateUpCommand.Execute(null);
+                    e.Handled = true;
+                }
+            }
+            else if (e.Key == System.Windows.Input.Key.Down)
+            {
+                if (_viewModel.NavigateDownCommand.CanExecute(null))
+                {
+                    _viewModel.NavigateDownCommand.Execute(null);
+                    e.Handled = true;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- listen for Up and Down arrow keys via `PreviewKeyDown` on `MainWindow`
- trigger `NavigateUpCommand` and `NavigateDownCommand` so invoice navigation works even inside text fields

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687993c7131c832295d74d0f2d949795