### PR TITLE
Enable scroll for validation error list

### DIFF
--- a/Views/InvoiceEditorView.xaml
+++ b/Views/InvoiceEditorView.xaml
@@ -21,7 +21,9 @@
                 Visibility="{Binding HasValidationErrors, Converter={StaticResource BoolToVisibilityConverter}}">
             <StackPanel>
                 <TextBlock Text="Hibák (Alt+1-6):" FontWeight="Bold" Margin="0,0,0,4" />
-                <ItemsControl ItemsSource="{Binding ValidationErrors}" />
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding ValidationErrors}" />
+                </ScrollViewer>
             </StackPanel>
         </Border>
     </Grid>


### PR DESCRIPTION
## Summary
- wrap validation error `ItemsControl` in a `ScrollViewer`

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879949bfefc832284c912a47dbd3f80