### PR TITLE
Add breadcrumb display

### DIFF
--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -44,6 +44,11 @@ namespace InvoiceApp.Services
         void SwitchRoot(AppState state);
 
         /// <summary>
+        /// Gets the current navigation path from the root window to the active state.
+        /// </summary>
+        IEnumerable<AppState> GetStatePath();
+
+        /// <summary>
         /// Raised whenever the current state changes.
         /// </summary>
         event EventHandler<AppState> StateChanged;

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using InvoiceApp.Models;
 
 namespace InvoiceApp.Services
@@ -74,6 +75,13 @@ namespace InvoiceApp.Services
             _substates.Clear();
             _history.Push(state);
             StateChanged?.Invoke(this, state);
+        }
+
+        public IEnumerable<AppState> GetStatePath()
+        {
+            var rootPath = _history.Reverse().Skip(1); // skip MainWindow
+            var subPath = _substates.Reverse();
+            return rootPath.Concat(subPath);
         }
     }
 }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using InvoiceApp.Models;
 using InvoiceApp.Services;
 using InvoiceApp;
@@ -13,6 +14,7 @@ namespace InvoiceApp.ViewModels
         private readonly INavigationService _navigation;
         private AppState _current;
         private string _currentStateDescription = string.Empty;
+        private string _breadcrumb = string.Empty;
         public InvoiceViewModel InvoiceViewModel { get; }
 
         public AppState CurrentState
@@ -32,6 +34,16 @@ namespace InvoiceApp.ViewModels
             private set
             {
                 _currentStateDescription = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string Breadcrumb
+        {
+            get => _breadcrumb;
+            private set
+            {
+                _breadcrumb = value;
                 OnPropertyChanged();
             }
         }
@@ -74,6 +86,7 @@ namespace InvoiceApp.ViewModels
             InvoiceViewModel = invoiceViewModel;
             _current = _navigation.CurrentState;
             _currentStateDescription = _current.GetDescription();
+            UpdateBreadcrumb();
             _navigation.StateChanged += OnStateChanged;
 
             BackCommand = new RelayCommand(_ => _navigation.Pop());
@@ -151,6 +164,20 @@ namespace InvoiceApp.ViewModels
         private void OnStateChanged(object? sender, AppState state)
         {
             CurrentState = state;
+            UpdateBreadcrumb();
+        }
+
+        private void UpdateBreadcrumb()
+        {
+            var path = _navigation.GetStatePath().ToList();
+            if (path.Count == 0)
+            {
+                Breadcrumb = CurrentStateDescription;
+            }
+            else
+            {
+                Breadcrumb = string.Join(" \u203a ", path.Select(s => s.GetDescription()));
+            }
         }
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -204,6 +204,10 @@
         <KeyBinding Key="F8" Command="{Binding ShowPaymentMethodsCommand}"/>
     </Window.InputBindings>
     <DockPanel>
+        <TextBlock DockPanel.Dock="Top"
+                   Text="{Binding Breadcrumb}"
+                   FontWeight="Bold"
+                   Margin="4" />
         <StatusBar DockPanel.Dock="Bottom">
             <TextBlock Text="{Binding CurrentStateDescription}" Margin="0,0,10,0"/>
             <TextBlock Text="{Binding InvoiceViewModel.StatusMessage}" />


### PR DESCRIPTION
## Summary
- expose navigation path through `INavigationService`
- build breadcrumb string in `MainViewModel`
- show breadcrumb at the top of `MainWindow`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68799970be0c8322a6dac1fe5c4d1123