### PR TITLE
Fix arrow keys editing state

### DIFF
--- a/Docs/UIKeyboardNavigation.md
+++ b/Docs/UIKeyboardNavigation.md
@@ -34,6 +34,8 @@ list.
 - `Del` deletes the highlighted invoice.
 - `Escape` returns to the dashboard.
 - Pressing `Up` before the first entry prompts to create a new invoice.
+- Up/Down arrows only move the list when the list is active and no row
+  details editor is visible.
 
 ### InvoiceEditor (`InvoiceEditorView`)
 

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -31,6 +31,14 @@ namespace InvoiceApp.Views
                 return;
             }
 
+            // Only allow list navigation when the invoice list is active and
+            // no row details panel is open
+            if (_viewModel.CurrentState != Models.AppState.InvoiceList ||
+                _viewModel.InvoiceViewModel.IsRowDetailsVisible)
+            {
+                return;
+            }
+
             if (e.Key == System.Windows.Input.Key.Up)
             {
                 if (_viewModel.NavigateUpCommand.CanExecute(null))


### PR DESCRIPTION
## Summary
- check current state and row details in `Window_PreviewKeyDown`
- document that arrow navigation is state-sensitive

## Testing
- `grep -n "TODO" -r | head`

------
https://chatgpt.com/codex/tasks/task_e_6879febf7e588322aa9b08c691421dcd