### PR TITLE
Fix VAT calculation logic

### DIFF
--- a/InvoiceApp.Tests/GlobalUsings.cs
+++ b/InvoiceApp.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;
+

--- a/InvoiceApp.Tests/InvoiceApp.Tests.csproj
+++ b/InvoiceApp.Tests/InvoiceApp.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <ProjectReference Include="..\InvoiceApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/InvoiceApp.Tests/InvoiceViewModelTests.cs
+++ b/InvoiceApp.Tests/InvoiceViewModelTests.cs
@@ -1,0 +1,117 @@
+using System.Collections.ObjectModel;
+using InvoiceApp.ViewModels;
+using InvoiceApp.Models;
+using InvoiceApp.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace InvoiceApp.Tests
+{
+    [TestClass]
+    public class InvoiceViewModelTests
+    {
+        private class StubService<T> : IInvoiceService, IInvoiceItemService, IProductService,
+            ITaxRateService, ISupplierService, IPaymentMethodService, IChangeLogService, INavigationService
+            where T : class, new()
+        {
+            // Implement all interfaces with no-op or default results
+            AppState INavigationService.CurrentState => AppState.Dashboard;
+            public event System.EventHandler<AppState>? StateChanged;
+            public void ClearSubstates() { }
+            public Task DeleteAsync(int id) => Task.CompletedTask;
+            public IEnumerable<AppState> GetStatePath() => Enumerable.Empty<AppState>();
+            public Task<IEnumerable<Invoice>> GetAllAsync() => Task.FromResult(Enumerable.Empty<Invoice>());
+            public Task<IEnumerable<InvoiceItem>> GetAllAsync() => Task.FromResult(Enumerable.Empty<InvoiceItem>());
+            public Task<IEnumerable<Product>> GetAllAsync() => Task.FromResult(Enumerable.Empty<Product>());
+            public Task<IEnumerable<TaxRate>> GetAllAsync() => Task.FromResult(Enumerable.Empty<TaxRate>());
+            public Task<IEnumerable<Supplier>> GetAllAsync() => Task.FromResult(Enumerable.Empty<Supplier>());
+            public Task<IEnumerable<PaymentMethod>> GetAllAsync() => Task.FromResult(Enumerable.Empty<PaymentMethod>());
+            public Task<Invoice?> GetByIdAsync(int id) => Task.FromResult<Invoice?>(null);
+            public Task<InvoiceItem?> GetByIdAsync(int id) => Task.FromResult<InvoiceItem?>(null);
+            public Task<Product?> GetByIdAsync(int id) => Task.FromResult<Product?>(null);
+            public Task<TaxRate?> GetByIdAsync(int id) => Task.FromResult<TaxRate?>(null);
+            public Task<Supplier?> GetByIdAsync(int id) => Task.FromResult<Supplier?>(null);
+            public Task<PaymentMethod?> GetByIdAsync(int id) => Task.FromResult<PaymentMethod?>(null);
+            public Task<Invoice?> GetLatestForSupplierAsync(int supplierId) => Task.FromResult<Invoice?>(null);
+            public Task<Invoice?> GetLatestAsync() => Task.FromResult<Invoice?>(null);
+            public Task SaveAsync(Invoice invoice) => Task.CompletedTask;
+            public Task SaveAsync(InvoiceItem item) => Task.CompletedTask;
+            public Task SaveAsync(Product product) => Task.CompletedTask;
+            public Task SaveAsync(TaxRate rate) => Task.CompletedTask;
+            public Task SaveAsync(Supplier supplier) => Task.CompletedTask;
+            public Task SaveAsync(PaymentMethod method) => Task.CompletedTask;
+            public void AddAsync(ChangeLog log) { }
+            Task IChangeLogService.AddAsync(ChangeLog log) { AddAsync(log); return Task.CompletedTask; }
+            Task<ChangeLog?> IChangeLogService.GetLatestAsync() => Task.FromResult<ChangeLog?>(null);
+            public void Pop() { }
+            public void PopSubstate() { }
+            public void Push(AppState state) { }
+            public void PushSubstate(AppState state) { }
+            public void SwitchRoot(AppState state) { }
+        }
+
+        private static InvoiceViewModel CreateViewModel()
+        {
+            var stub = new StubService<object>();
+            return new InvoiceViewModel(stub, stub, stub, stub, stub, stub, stub,
+                new SupplierViewModel(stub), stub);
+        }
+
+        [TestMethod]
+        public void CalculatesTotals_ForNetMode()
+        {
+            var vm = CreateViewModel();
+            vm.SelectedInvoice = new Invoice { IsGross = false };
+            var items = new ObservableCollection<InvoiceItemViewModel>
+            {
+                new InvoiceItemViewModel(new InvoiceItem
+                {
+                    Quantity = 2,
+                    UnitPrice = 100,
+                    TaxRate = new TaxRate { Percentage = 27m }
+                }) { TaxRatePercentage = 27m },
+                new InvoiceItemViewModel(new InvoiceItem
+                {
+                    Quantity = 1,
+                    UnitPrice = 50,
+                    TaxRate = new TaxRate { Percentage = 5m }
+                }) { TaxRatePercentage = 5m }
+            };
+            vm.Items = items;
+            vm.IsGrossCalculation = false;
+
+            Assert.AreEqual(250m, vm.TotalNet);
+            Assert.AreEqual(56.5m, vm.TotalVat);
+            Assert.AreEqual(306.5m, vm.TotalGross);
+        }
+
+        [TestMethod]
+        public void CalculatesTotals_ForGrossMode()
+        {
+            var vm = CreateViewModel();
+            vm.SelectedInvoice = new Invoice { IsGross = true };
+            var items = new ObservableCollection<InvoiceItemViewModel>
+            {
+                new InvoiceItemViewModel(new InvoiceItem
+                {
+                    Quantity = 2,
+                    UnitPrice = 127,
+                    TaxRate = new TaxRate { Percentage = 27m }
+                }) { TaxRatePercentage = 27m },
+                new InvoiceItemViewModel(new InvoiceItem
+                {
+                    Quantity = 1,
+                    UnitPrice = 52.5m,
+                    TaxRate = new TaxRate { Percentage = 5m }
+                }) { TaxRatePercentage = 5m }
+            };
+            vm.Items = items;
+            vm.IsGrossCalculation = true;
+
+            Assert.AreEqual(250m, vm.TotalNet);
+            Assert.AreEqual(56.5m, vm.TotalVat);
+            Assert.AreEqual(306.5m, vm.TotalGross);
+        }
+    }
+}

--- a/InvoiceApp.sln
+++ b/InvoiceApp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36221.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvoiceApp", "InvoiceApp.csproj", "{95645962-860D-452D-A75C-BE0D0BBC492E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvoiceApp.Tests", "InvoiceApp.Tests\InvoiceApp.Tests.csproj", "{1CD9D602-5B87-49C9-9469-A1BB981C05EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{95645962-860D-452D-A75C-BE0D0BBC492E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95645962-860D-452D-A75C-BE0D0BBC492E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95645962-860D-452D-A75C-BE0D0BBC492E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CD9D602-5B87-49C9-9469-A1BB981C05EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CD9D602-5B87-49C9-9469-A1BB981C05EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CD9D602-5B87-49C9-9469-A1BB981C05EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CD9D602-5B87-49C9-9469-A1BB981C05EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -720,8 +720,10 @@ namespace InvoiceApp.ViewModels
                 .GroupBy(i => i.TaxRatePercentage)
                 .Select(g =>
                 {
-                    var net = g.Sum(x => x.Quantity * x.UnitPrice);
-                    var vat = IsGrossCalculation ? net * g.Key / 100m : 0m;
+                    decimal net = IsGrossCalculation
+                        ? g.Sum(x => x.Quantity * x.UnitPrice / (1m + g.Key / 100m))
+                        : g.Sum(x => x.Quantity * x.UnitPrice);
+                    decimal vat = net * g.Key / 100m;
                     return new VatBreakdownEntry
                     {
                         Rate = g.Key,
@@ -732,7 +734,7 @@ namespace InvoiceApp.ViewModels
 
             VatBreakdown = new ObservableCollection<VatBreakdownEntry>(breakdown);
             TotalNet = VatBreakdown.Sum(v => v.Net);
-            TotalVat = IsGrossCalculation ? VatBreakdown.Sum(v => v.Vat) : 0m;
+            TotalVat = VatBreakdown.Sum(v => v.Vat);
             TotalGross = TotalNet + TotalVat;
             InWords = $"In Words: {NumberToWords((long)TotalGross)} Forint";
         }


### PR DESCRIPTION
## Summary
- recompute VAT always from net amounts
- add InvoiceApp.Tests MSTest project
- implement tests for net and gross calculation modes

## Testing
- `dotnet test InvoiceApp.Tests/InvoiceApp.Tests.csproj --no-build` *(fails: invalid arguments)*
- `dotnet test InvoiceApp.Tests/InvoiceApp.Tests.csproj -v minimal` *(fails: windowsdesktop SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a0d77b9e48322881a63916942def5