### PR TITLE
Streamlined invoice validation via FluentValidator

### DIFF
--- a/InvoiceApp.Tests/InvoiceValidationTests.cs
+++ b/InvoiceApp.Tests/InvoiceValidationTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using InvoiceApp.Models;
+using InvoiceApp.ViewModels;
+
+namespace InvoiceApp.Tests
+{
+    [TestClass]
+    public class InvoiceValidationTests
+    {
+        [TestMethod]
+        public void InvoiceIsInvalid_WhenRequiredFieldsMissing()
+        {
+            var invoice = new Invoice();
+            Assert.IsFalse(invoice.IsValid());
+        }
+
+        [TestMethod]
+        public void ViewModel_PreventsSave_ForInvalidInvoice()
+        {
+            var vm = TestHelpers.CreateInvoiceViewModel();
+            vm.SelectedInvoice = new Invoice();
+            vm.Items = new ObservableCollection<InvoiceItemViewModel>
+            {
+                new InvoiceItemViewModel(new InvoiceItem
+                {
+                    Quantity = 1,
+                    UnitPrice = 10,
+                    TaxRate = new TaxRate { Percentage = 27m }
+                }) { TaxRatePercentage = 27m }
+            };
+            Assert.IsFalse(vm.SaveCommand.CanExecute(null));
+        }
+    }
+}

--- a/InvoiceApp.Tests/InvoiceViewModelTests.cs
+++ b/InvoiceApp.Tests/InvoiceViewModelTests.cs
@@ -1,67 +1,18 @@
 using System.Collections.ObjectModel;
 using InvoiceApp.ViewModels;
 using InvoiceApp.Models;
-using InvoiceApp.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Threading.Tasks;
-using System.Linq;
 
 namespace InvoiceApp.Tests
 {
     [TestClass]
     public class InvoiceViewModelTests
     {
-        private class StubService<T> : IInvoiceService, IInvoiceItemService, IProductService,
-            ITaxRateService, ISupplierService, IPaymentMethodService, IChangeLogService, INavigationService
-            where T : class, new()
-        {
-            // Implement all interfaces with no-op or default results
-            AppState INavigationService.CurrentState => AppState.Dashboard;
-            public event System.EventHandler<AppState>? StateChanged;
-            public void ClearSubstates() { }
-            public Task DeleteAsync(int id) => Task.CompletedTask;
-            public IEnumerable<AppState> GetStatePath() => Enumerable.Empty<AppState>();
-            public Task<IEnumerable<Invoice>> GetAllAsync() => Task.FromResult(Enumerable.Empty<Invoice>());
-            public Task<IEnumerable<InvoiceItem>> GetAllAsync() => Task.FromResult(Enumerable.Empty<InvoiceItem>());
-            public Task<IEnumerable<Product>> GetAllAsync() => Task.FromResult(Enumerable.Empty<Product>());
-            public Task<IEnumerable<TaxRate>> GetAllAsync() => Task.FromResult(Enumerable.Empty<TaxRate>());
-            public Task<IEnumerable<Supplier>> GetAllAsync() => Task.FromResult(Enumerable.Empty<Supplier>());
-            public Task<IEnumerable<PaymentMethod>> GetAllAsync() => Task.FromResult(Enumerable.Empty<PaymentMethod>());
-            public Task<Invoice?> GetByIdAsync(int id) => Task.FromResult<Invoice?>(null);
-            public Task<InvoiceItem?> GetByIdAsync(int id) => Task.FromResult<InvoiceItem?>(null);
-            public Task<Product?> GetByIdAsync(int id) => Task.FromResult<Product?>(null);
-            public Task<TaxRate?> GetByIdAsync(int id) => Task.FromResult<TaxRate?>(null);
-            public Task<Supplier?> GetByIdAsync(int id) => Task.FromResult<Supplier?>(null);
-            public Task<PaymentMethod?> GetByIdAsync(int id) => Task.FromResult<PaymentMethod?>(null);
-            public Task<Invoice?> GetLatestForSupplierAsync(int supplierId) => Task.FromResult<Invoice?>(null);
-            public Task<Invoice?> GetLatestAsync() => Task.FromResult<Invoice?>(null);
-            public Task SaveAsync(Invoice invoice) => Task.CompletedTask;
-            public Task SaveAsync(InvoiceItem item) => Task.CompletedTask;
-            public Task SaveAsync(Product product) => Task.CompletedTask;
-            public Task SaveAsync(TaxRate rate) => Task.CompletedTask;
-            public Task SaveAsync(Supplier supplier) => Task.CompletedTask;
-            public Task SaveAsync(PaymentMethod method) => Task.CompletedTask;
-            public void AddAsync(ChangeLog log) { }
-            Task IChangeLogService.AddAsync(ChangeLog log) { AddAsync(log); return Task.CompletedTask; }
-            Task<ChangeLog?> IChangeLogService.GetLatestAsync() => Task.FromResult<ChangeLog?>(null);
-            public void Pop() { }
-            public void PopSubstate() { }
-            public void Push(AppState state) { }
-            public void PushSubstate(AppState state) { }
-            public void SwitchRoot(AppState state) { }
-        }
-
-        private static InvoiceViewModel CreateViewModel()
-        {
-            var stub = new StubService<object>();
-            return new InvoiceViewModel(stub, stub, stub, stub, stub, stub, stub,
-                new SupplierViewModel(stub), stub);
-        }
 
         [TestMethod]
         public void CalculatesTotals_ForNetMode()
         {
-            var vm = CreateViewModel();
+            var vm = TestHelpers.CreateInvoiceViewModel();
             vm.SelectedInvoice = new Invoice { IsGross = false };
             var items = new ObservableCollection<InvoiceItemViewModel>
             {
@@ -89,7 +40,7 @@ namespace InvoiceApp.Tests
         [TestMethod]
         public void CalculatesTotals_ForGrossMode()
         {
-            var vm = CreateViewModel();
+            var vm = TestHelpers.CreateInvoiceViewModel();
             vm.SelectedInvoice = new Invoice { IsGross = true };
             var items = new ObservableCollection<InvoiceItemViewModel>
             {

--- a/InvoiceApp.Tests/TestHelpers.cs
+++ b/InvoiceApp.Tests/TestHelpers.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using InvoiceApp.Models;
+using InvoiceApp.Services;
+using InvoiceApp.ViewModels;
+
+namespace InvoiceApp.Tests
+{
+    internal class StubService<T> : IInvoiceService, IInvoiceItemService, IProductService,
+        ITaxRateService, ISupplierService, IPaymentMethodService, IChangeLogService, INavigationService
+        where T : class, new()
+    {
+        AppState INavigationService.CurrentState => AppState.Dashboard;
+        public event System.EventHandler<AppState>? StateChanged;
+        public void ClearSubstates() { }
+        public Task DeleteAsync(int id) => Task.CompletedTask;
+        public IEnumerable<AppState> GetStatePath() => Enumerable.Empty<AppState>();
+        public Task<IEnumerable<Invoice>> GetAllAsync() => Task.FromResult(Enumerable.Empty<Invoice>());
+        Task<IEnumerable<InvoiceItem>> IInvoiceItemService.GetAllAsync() => Task.FromResult(Enumerable.Empty<InvoiceItem>());
+        Task<IEnumerable<Product>> IProductService.GetAllAsync() => Task.FromResult(Enumerable.Empty<Product>());
+        Task<IEnumerable<TaxRate>> ITaxRateService.GetAllAsync() => Task.FromResult(Enumerable.Empty<TaxRate>());
+        Task<IEnumerable<Supplier>> ISupplierService.GetAllAsync() => Task.FromResult(Enumerable.Empty<Supplier>());
+        Task<IEnumerable<PaymentMethod>> IPaymentMethodService.GetAllAsync() => Task.FromResult(Enumerable.Empty<PaymentMethod>());
+        public Task<Invoice?> GetByIdAsync(int id) => Task.FromResult<Invoice?>(null);
+        Task<InvoiceItem?> IInvoiceItemService.GetByIdAsync(int id) => Task.FromResult<InvoiceItem?>(null);
+        Task<Product?> IProductService.GetByIdAsync(int id) => Task.FromResult<Product?>(null);
+        Task<TaxRate?> ITaxRateService.GetByIdAsync(int id) => Task.FromResult<TaxRate?>(null);
+        Task<Supplier?> ISupplierService.GetByIdAsync(int id) => Task.FromResult<Supplier?>(null);
+        Task<PaymentMethod?> IPaymentMethodService.GetByIdAsync(int id) => Task.FromResult<PaymentMethod?>(null);
+        public Task<Invoice?> GetLatestForSupplierAsync(int supplierId) => Task.FromResult<Invoice?>(null);
+        public Task<Invoice?> GetLatestAsync() => Task.FromResult<Invoice?>(null);
+        public Task SaveAsync(Invoice invoice) => Task.CompletedTask;
+        Task IInvoiceItemService.SaveAsync(InvoiceItem item) => Task.CompletedTask;
+        Task IProductService.SaveAsync(Product product) => Task.CompletedTask;
+        Task ITaxRateService.SaveAsync(TaxRate rate) => Task.CompletedTask;
+        Task ISupplierService.SaveAsync(Supplier supplier) => Task.CompletedTask;
+        Task IPaymentMethodService.SaveAsync(PaymentMethod method) => Task.CompletedTask;
+        public void AddAsync(ChangeLog log) { }
+        Task IChangeLogService.AddAsync(ChangeLog log) { AddAsync(log); return Task.CompletedTask; }
+        Task<ChangeLog?> IChangeLogService.GetLatestAsync() => Task.FromResult<ChangeLog?>(null);
+        public void Pop() { }
+        public void PopSubstate() { }
+        public void Push(AppState state) { }
+        public void PushSubstate(AppState state) { }
+        public void SwitchRoot(AppState state) { }
+        public bool IsValid(Invoice invoice) => invoice.IsValid();
+    }
+
+    internal static class TestHelpers
+    {
+        public static InvoiceViewModel CreateInvoiceViewModel()
+        {
+            var stub = new StubService<object>();
+            return new InvoiceViewModel(stub, stub, stub, stub, stub, stub, stub,
+                new SupplierViewModel(stub), stub);
+        }
+    }
+}

--- a/Models/Invoice.cs
+++ b/Models/Invoice.cs
@@ -115,12 +115,13 @@ namespace InvoiceApp.Models
             if (propertyName != null) Validate(propertyName);
         }
 
+        /// <summary>
+        /// Validates the invoice using <see cref="InvoiceDtoValidator"/>.
+        /// </summary>
+        /// <returns>true if the invoice passes all validation rules; otherwise false.</returns>
         public bool IsValid()
         {
-            return !string.IsNullOrWhiteSpace(Number)
-                && SupplierId != 0
-                && PaymentMethodId != 0
-                && Date != default;
+            return _validator.Validate(this.ToDto()).IsValid;
         }
     }
 }

--- a/Services/IInvoiceService.cs
+++ b/Services/IInvoiceService.cs
@@ -12,5 +12,6 @@ namespace InvoiceApp.Services
         Task<Invoice?> GetLatestAsync();
         Task SaveAsync(Invoice invoice);
         Task DeleteAsync(int id);
+        bool IsValid(Invoice invoice);
     }
 }

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -38,5 +38,10 @@ namespace InvoiceApp.Services
         {
             return _validator.ValidateAndThrowAsync(entity.ToDto());
         }
+
+        public bool IsValid(Invoice invoice)
+        {
+            return _validator.Validate(invoice.ToDto()).IsValid;
+        }
     }
 }

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -524,7 +524,9 @@ namespace InvoiceApp.ViewModels
 
         private bool Validate()
         {
-            return SelectedInvoice?.IsValid() == true && Items.Count > 0;
+            return SelectedInvoice != null
+                && _service.IsValid(SelectedInvoice)
+                && Items.Count > 0;
         }
 
         private async Task SaveAsync()


### PR DESCRIPTION
## Summary
- rely on `InvoiceDtoValidator` inside `Invoice.IsValid`
- expose `IsValid` via `IInvoiceService` and implement in `InvoiceService`
- adjust `InvoiceViewModel` to use the service-based check
- refactor test utilities and add new validation tests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a13bfffe08322a04d073b2b15b8f7