### PR TITLE
Fix services reference for ItemsViewModel

### DIFF
--- a/ViewModels/ItemsViewModel.cs
+++ b/ViewModels/ItemsViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using InvoiceApp.Models;
+using InvoiceApp.Services;
 
 namespace InvoiceApp.ViewModels
 {


### PR DESCRIPTION
## Summary
- resolve missing interface errors by adding InvoiceApp.Services namespace to ItemsViewModel

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a45390bd08322b3ccf24dc534e401