### PR TITLE
Add invoice amount calculator and update view models

### DIFF
--- a/Helpers/AmountCalculator.cs
+++ b/Helpers/AmountCalculator.cs
@@ -1,0 +1,27 @@
+namespace InvoiceApp.Helpers
+{
+    /// <summary>
+    /// Utility class for calculating invoice amounts.
+    /// </summary>
+    public static class AmountCalculator
+    {
+        public struct Amounts
+        {
+            public decimal Net { get; init; }
+            public decimal Vat { get; init; }
+            public decimal Gross => Net + Vat;
+        }
+
+        /// <summary>
+        /// Calculates net, VAT and gross amounts for an item.
+        /// </summary>
+        public static Amounts Calculate(decimal quantity, decimal unitPrice, decimal taxRate, bool isGross)
+        {
+            decimal net = isGross
+                ? quantity * unitPrice / (1m + taxRate / 100m)
+                : quantity * unitPrice;
+            decimal vat = net * taxRate / 100m;
+            return new Amounts { Net = net, Vat = vat };
+        }
+    }
+}

--- a/InvoiceApp.Tests/InvoiceItemCalculationTests.cs
+++ b/InvoiceApp.Tests/InvoiceItemCalculationTests.cs
@@ -1,0 +1,27 @@
+using InvoiceApp.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace InvoiceApp.Tests
+{
+    [TestClass]
+    public class InvoiceItemCalculationTests
+    {
+        [TestMethod]
+        public void CalculatesAmounts_ForNetMode()
+        {
+            var amounts = AmountCalculator.Calculate(2m, 100m, 27m, false);
+            Assert.AreEqual(200m, amounts.Net);
+            Assert.AreEqual(54m, amounts.Vat);
+            Assert.AreEqual(254m, amounts.Gross);
+        }
+
+        [TestMethod]
+        public void CalculatesAmounts_ForGrossMode()
+        {
+            var amounts = AmountCalculator.Calculate(2m, 127m, 27m, true);
+            Assert.AreEqual(200m, amounts.Net);
+            Assert.AreEqual(54m, amounts.Vat);
+            Assert.AreEqual(254m, amounts.Gross);
+        }
+    }
+}

--- a/ViewModels/InvoiceItemViewModel.cs
+++ b/ViewModels/InvoiceItemViewModel.cs
@@ -1,4 +1,5 @@
 using InvoiceApp.Models;
+using InvoiceApp.Helpers;
 
 namespace InvoiceApp.ViewModels
 {
@@ -43,6 +44,7 @@ namespace InvoiceApp.ViewModels
                 {
                     _isGross = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(NetAmount));
                     OnPropertyChanged(nameof(VatAmount));
                     OnPropertyChanged(nameof(GrossAmount));
                     OnPropertyChanged(nameof(Total));
@@ -115,6 +117,7 @@ namespace InvoiceApp.ViewModels
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(TaxRateId));
                     OnPropertyChanged(nameof(TaxRatePercentage));
+                    OnPropertyChanged(nameof(NetAmount));
                     OnPropertyChanged(nameof(VatAmount));
                     OnPropertyChanged(nameof(GrossAmount));
                     OnPropertyChanged(nameof(Total));
@@ -133,6 +136,7 @@ namespace InvoiceApp.ViewModels
                 {
                     _taxRatePercentage = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(NetAmount));
                     OnPropertyChanged(nameof(VatAmount));
                     OnPropertyChanged(nameof(GrossAmount));
                     OnPropertyChanged(nameof(Total));
@@ -140,11 +144,14 @@ namespace InvoiceApp.ViewModels
             }
         }
 
-        public decimal NetAmount => Quantity * UnitPrice;
+        private AmountCalculator.Amounts Calculate() =>
+            AmountCalculator.Calculate(Quantity, UnitPrice, TaxRatePercentage, IsGross);
 
-        public decimal VatAmount => IsGross ? NetAmount * TaxRatePercentage / 100m : 0m;
+        public decimal NetAmount => Calculate().Net;
 
-        public decimal GrossAmount => NetAmount + VatAmount;
+        public decimal VatAmount => Calculate().Vat;
+
+        public decimal GrossAmount => Calculate().Gross;
 
         public decimal Total => GrossAmount;
     }

--- a/ViewModels/ItemsViewModel.cs
+++ b/ViewModels/ItemsViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using InvoiceApp.Models;
 using InvoiceApp.Services;
+using InvoiceApp.Helpers;
 
 namespace InvoiceApp.ViewModels
 {
@@ -277,10 +278,18 @@ namespace InvoiceApp.ViewModels
                 .GroupBy(i => i.TaxRatePercentage)
                 .Select(g =>
                 {
-                    decimal net = _isGrossFunc()
-                        ? g.Sum(x => x.Quantity * x.UnitPrice / (1m + g.Key / 100m))
-                        : g.Sum(x => x.Quantity * x.UnitPrice);
-                    decimal vat = net * g.Key / 100m;
+                    decimal net = 0m;
+                    decimal vat = 0m;
+                    foreach (var item in g)
+                    {
+                        var amounts = AmountCalculator.Calculate(
+                            item.Quantity,
+                            item.UnitPrice,
+                            g.Key,
+                            IsGross);
+                        net += amounts.Net;
+                        vat += amounts.Vat;
+                    }
                     return new VatBreakdownEntry
                     {
                         Rate = g.Key,


### PR DESCRIPTION
## Summary
- implement `AmountCalculator` helper for net/VAT/gross calculations
- use helper in `InvoiceItemViewModel` and raise property changes appropriately
- refactor `ItemsViewModel.UpdateTotals` to leverage helper
- add unit tests for calculation modes

## Testing
- `dotnet test --no-build` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_687a6425b55c8322ac24d22e7744efa1