### PR TITLE
Add transactional invoice saving

### DIFF
--- a/InvoiceApp.Tests/InvoiceApp.Tests.csproj
+++ b/InvoiceApp.Tests/InvoiceApp.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <ProjectReference Include="..\InvoiceApp.csproj" />
   </ItemGroup>
 

--- a/InvoiceApp.Tests/InvoiceServiceTests.cs
+++ b/InvoiceApp.Tests/InvoiceServiceTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using InvoiceApp.Data;
+using InvoiceApp.Models;
+using InvoiceApp.Services;
+using InvoiceApp.DTOs;
+using InvoiceApp.Repositories;
+using InvoiceApp.Validators;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace InvoiceApp.Tests
+{
+    internal class StubInvoiceRepository : IInvoiceRepository
+    {
+        public Task<IEnumerable<Invoice>> GetAllAsync() => Task.FromResult<IEnumerable<Invoice>>(Array.Empty<Invoice>());
+        public Task<Invoice?> GetByIdAsync(int id) => Task.FromResult<Invoice?>(null);
+        public Task AddAsync(Invoice entity) => Task.CompletedTask;
+        public Task UpdateAsync(Invoice entity) => Task.CompletedTask;
+        public Task DeleteAsync(int id) => Task.CompletedTask;
+        public Task<Invoice?> GetLatestForSupplierAsync(int supplierId) => Task.FromResult<Invoice?>(null);
+        public Task<Invoice?> GetLatestAsync() => Task.FromResult<Invoice?>(null);
+    }
+
+    internal class StubChangeLogService : IChangeLogService
+    {
+        public Task AddAsync(ChangeLog log) => Task.CompletedTask;
+        public Task<ChangeLog?> GetLatestAsync() => Task.FromResult<ChangeLog?>(null);
+    }
+
+    internal class ThrowEnumerable<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> _items;
+        private readonly int _throwAfter;
+        public ThrowEnumerable(IEnumerable<T> items, int throwAfter)
+        {
+            _items = items;
+            _throwAfter = throwAfter;
+        }
+        public IEnumerator<T> GetEnumerator()
+        {
+            int i = 0;
+            foreach (var item in _items)
+            {
+                if (i++ == _throwAfter) throw new Exception("fail");
+                yield return item;
+            }
+        }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    [TestClass]
+    public class InvoiceServiceTests
+    {
+        private InvoiceService CreateService(string dbName)
+        {
+            var options = new DbContextOptionsBuilder<InvoiceContext>()
+                .UseInMemoryDatabase(dbName)
+                .Options;
+            var factory = new PooledDbContextFactory<InvoiceContext>(options);
+            return new InvoiceService(new StubInvoiceRepository(), new StubChangeLogService(), new InvoiceDtoValidator(), factory);
+        }
+
+        [TestMethod]
+        public async Task SaveInvoiceWithItemsAsync_SavesAll()
+        {
+            var service = CreateService(nameof(SaveInvoiceWithItemsAsync_SavesAll));
+            var supplier = new Supplier { Name = "Test" };
+            var invoice = new Invoice { Number = "1", Date = DateTime.Today, Supplier = supplier, PaymentMethodId = 0 };
+            var item = new InvoiceItem { Quantity = 1, UnitPrice = 10 };
+            await service.SaveInvoiceWithItemsAsync(invoice, new[] { item });
+
+            using var ctx = ((PooledDbContextFactory<InvoiceContext>)service.GetType().GetField("_contextFactory", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(service) as IDbContextFactory<InvoiceContext>)!.CreateDbContext();
+            Assert.AreEqual(1, ctx.Invoices.Count());
+            Assert.AreEqual(1, ctx.InvoiceItems.Count());
+            Assert.AreEqual(1, ctx.Suppliers.Count());
+        }
+
+        [TestMethod]
+        public async Task SaveInvoiceWithItemsAsync_RollsBackOnFailure()
+        {
+            var service = CreateService(nameof(SaveInvoiceWithItemsAsync_RollsBackOnFailure));
+            var supplier = new Supplier { Name = "Test" };
+            var invoice = new Invoice { Number = "1", Date = DateTime.Today, Supplier = supplier, PaymentMethodId = 0 };
+            var items = new[] { new InvoiceItem { Quantity = 1, UnitPrice = 10 }, new InvoiceItem { Quantity = 2, UnitPrice = 20 } };
+            var throwing = new ThrowEnumerable<InvoiceItem>(items, 1);
+            await Assert.ThrowsExceptionAsync<Exception>(() => service.SaveInvoiceWithItemsAsync(invoice, throwing));
+
+            using var ctx = ((PooledDbContextFactory<InvoiceContext>)service.GetType().GetField("_contextFactory", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(service) as IDbContextFactory<InvoiceContext>)!.CreateDbContext();
+            Assert.AreEqual(0, ctx.Invoices.Count());
+            Assert.AreEqual(0, ctx.InvoiceItems.Count());
+            Assert.AreEqual(0, ctx.Suppliers.Count());
+        }
+    }
+}

--- a/Services/IInvoiceService.cs
+++ b/Services/IInvoiceService.cs
@@ -11,6 +11,7 @@ namespace InvoiceApp.Services
         Task<Invoice?> GetLatestForSupplierAsync(int supplierId);
         Task<Invoice?> GetLatestAsync();
         Task SaveAsync(Invoice invoice);
+        Task SaveInvoiceWithItemsAsync(Invoice invoice, IEnumerable<InvoiceItem> items);
         Task DeleteAsync(int id);
         bool IsValid(Invoice invoice);
     }

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using InvoiceApp.Models;
@@ -6,6 +7,8 @@ using InvoiceApp.DTOs;
 using InvoiceApp.Mappers;
 using FluentValidation;
 using Serilog;
+using Microsoft.EntityFrameworkCore;
+using InvoiceApp.Data;
 
 namespace InvoiceApp.Services
 {
@@ -13,12 +16,14 @@ namespace InvoiceApp.Services
     {
         private readonly IInvoiceRepository _repository;
         private readonly IValidator<InvoiceDto> _validator;
+        private readonly IDbContextFactory<InvoiceContext> _contextFactory;
 
-        public InvoiceService(IInvoiceRepository repository, IChangeLogService logService, IValidator<InvoiceDto> validator)
+        public InvoiceService(IInvoiceRepository repository, IChangeLogService logService, IValidator<InvoiceDto> validator, IDbContextFactory<InvoiceContext> contextFactory)
             : base(repository, logService)
         {
             _repository = repository;
             _validator = validator;
+            _contextFactory = contextFactory;
         }
 
 
@@ -42,6 +47,87 @@ namespace InvoiceApp.Services
         public bool IsValid(Invoice invoice)
         {
             return _validator.Validate(invoice.ToDto()).IsValid;
+        }
+
+        public async Task SaveInvoiceWithItemsAsync(Invoice invoice, IEnumerable<InvoiceItem> items)
+        {
+            if (invoice == null) throw new ArgumentNullException(nameof(invoice));
+            if (items == null) throw new ArgumentNullException(nameof(items));
+
+            await ValidateAsync(invoice);
+
+            using var ctx = _contextFactory.CreateDbContext();
+            using var trx = await ctx.Database.BeginTransactionAsync();
+            try
+            {
+                if (invoice.Supplier != null)
+                {
+                    if (invoice.Supplier.Id == 0)
+                    {
+                        invoice.Supplier.DateCreated = DateTime.Now;
+                        invoice.Supplier.DateUpdated = invoice.Supplier.DateCreated;
+                        invoice.Supplier.Active = true;
+                        await ctx.Suppliers.AddAsync(invoice.Supplier);
+                    }
+                    else
+                    {
+                        ctx.Suppliers.Update(invoice.Supplier);
+                    }
+                }
+
+                if (invoice.PaymentMethod != null)
+                {
+                    ctx.Attach(invoice.PaymentMethod);
+                }
+
+                if (invoice.Id == 0)
+                {
+                    invoice.DateCreated = DateTime.Now;
+                    invoice.DateUpdated = invoice.DateCreated;
+                    invoice.Active = true;
+                    await ctx.Invoices.AddAsync(invoice);
+                }
+                else
+                {
+                    invoice.DateUpdated = DateTime.Now;
+                    ctx.Invoices.Update(invoice);
+                }
+
+                foreach (var item in items)
+                {
+                    if (item.Product != null)
+                    {
+                        ctx.Attach(item.Product);
+                    }
+                    if (item.TaxRate != null)
+                    {
+                        ctx.Attach(item.TaxRate);
+                    }
+                    item.Invoice = invoice;
+                    item.InvoiceId = invoice.Id;
+
+                    if (item.Id == 0)
+                    {
+                        item.DateCreated = DateTime.Now;
+                        item.DateUpdated = item.DateCreated;
+                        item.Active = true;
+                        await ctx.InvoiceItems.AddAsync(item);
+                    }
+                    else
+                    {
+                        item.DateUpdated = DateTime.Now;
+                        ctx.InvoiceItems.Update(item);
+                    }
+                }
+
+                await ctx.SaveChangesAsync();
+                await trx.CommitAsync();
+            }
+            catch
+            {
+                await trx.RollbackAsync();
+                throw;
+            }
         }
     }
 }

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -539,11 +539,6 @@ namespace InvoiceApp.ViewModels
             }
 
             SelectedInvoice.Items = Items.Select(vm => vm.Item).ToList();
-            if (SelectedSupplier != null)
-            {
-                await _supplierService.SaveAsync(SelectedSupplier);
-            }
-            await _service.SaveAsync(SelectedInvoice);
 
             foreach (var vm in Items)
             {
@@ -574,8 +569,9 @@ namespace InvoiceApp.ViewModels
                     it.Product.TaxRateId = rate.Id;
                     await _productService.SaveAsync(it.Product);
                 }
-                await _itemService.SaveAsync(it);
             }
+
+            await _service.SaveInvoiceWithItemsAsync(SelectedInvoice, Items.Select(i => i.Item));
 
             ShowStatus($"Számla mentve. ({DateTime.Now:g})");
             Log.Information("Invoice {Id} saved", SelectedInvoice.Id);


### PR DESCRIPTION
## Summary
- add `SaveInvoiceWithItemsAsync` to `InvoiceService` and interface
- support one context and transaction when saving invoice and items
- refactor `InvoiceViewModel.SaveAsync` to use the new service method
- include unit tests covering success and rollback behaviour
- reference EF InMemory provider for tests

## Testing
- `dotnet test --no-build` *(fails: SDK `Microsoft.NET.Sdk.WindowsDesktop` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a661b165c83229ba0fd78d9a53e67