### PR TITLE
Remove obsolete InvoiceEditor state

### DIFF
--- a/Docs/AppStateNavigation.md
+++ b/Docs/AppStateNavigation.md
@@ -9,7 +9,6 @@ This document lists the official `AppState` values used by InvoiceApp and the de
 | `MainWindow` | Root container window for the application. |
 | `Dashboard` | Overview screen showing recent activity. |
 | `InvoiceList` | Displays all invoices. |
-| `InvoiceEditor` | (unused) Former container for invoice editing. |
 | `Header` | Editor substate for header information. |
 | `ItemList` | Editor substate for editing invoice items. |
 | `Summary` | Editor substate summarising totals. |

--- a/Docs/UIKeyboardNavigation.md
+++ b/Docs/UIKeyboardNavigation.md
@@ -33,17 +33,6 @@ Press `Up` at the start of a list to quickly create a new entry.
 - `Escape` returns to the dashboard.
 - Pressing `Up` before the first entry prompts to create a new invoice.
 
-### InvoiceEditor (`InvoiceEditorView`)
-
-- Consists of `InvoiceHeaderView`, `InvoiceItemDataGrid` and
-  `InvoiceSummaryPanel`.
-- `Enter` advances to the next field; on the last field it moves to the next
-  editor step.
-- `Escape` cancels editing and returns to the invoice list.
-- `Ins` adds a new item while the item grid is focused.
-- `Del` removes the selected item from the grid.
-- `Up`/`Down` navigate rows in the item grid; `Left`/`Right` move within cells.
-- Pressing `Up` on the first row prompts to create a new item.
 
 ### Products (`ProductView`)
 

--- a/Helpers/AppStateTemplateSelector.cs
+++ b/Helpers/AppStateTemplateSelector.cs
@@ -19,7 +19,6 @@ namespace InvoiceApp.Helpers
         public DataTemplate? ProductsTemplate { get; set; }
         public DataTemplate? DashboardTemplate { get; set; }
         public DataTemplate? InvoiceListTemplate { get; set; }
-        public DataTemplate? InvoiceEditorTemplate { get; set; }
         public DataTemplate? HeaderTemplate { get; set; }
         public DataTemplate? ItemListTemplate { get; set; }
         public DataTemplate? SummaryTemplate { get; set; }
@@ -40,7 +39,6 @@ namespace InvoiceApp.Helpers
                 AppState.Products => ProductsTemplate,
                 AppState.Dashboard => DashboardTemplate,
                 AppState.InvoiceList => InvoiceListTemplate,
-                AppState.InvoiceEditor => MainWindowTemplate,
                 AppState.Header => MainWindowTemplate,
                 AppState.ItemList => MainWindowTemplate,
                 AppState.Summary => MainWindowTemplate,

--- a/Models/AppState.cs
+++ b/Models/AppState.cs
@@ -21,10 +21,6 @@ namespace InvoiceApp.Models
         /// </summary>
         InvoiceList,
         /// <summary>
-        /// Container for creating or editing invoices.
-        /// </summary>
-        InvoiceEditor,
-        /// <summary>
         /// Invoice header information step.
         /// </summary>
         Header,
@@ -84,7 +80,6 @@ namespace InvoiceApp.Models
             AppState.MainWindow => typeof(MainWindow),
             AppState.Dashboard => typeof(DashboardView),
             AppState.InvoiceList => typeof(InvoiceListView),
-            AppState.InvoiceEditor => typeof(InvoiceEditorView),
             AppState.Header => typeof(InvoiceHeaderView),
             AppState.ItemList => typeof(InvoiceItemDataGrid),
             AppState.Summary => typeof(InvoiceSummaryPanel),
@@ -109,7 +104,6 @@ namespace InvoiceApp.Models
             AppState.MainWindow => "F\u0151ablak",
             AppState.Dashboard => "Vez\u00e9rl\u0151pult",
             AppState.InvoiceList => "Sz\u00e1ml\u00e1k",
-            AppState.InvoiceEditor => "Sz\u00e1mlaszerkeszt\u0151",
             AppState.Header => "Fejl\u00e9c",
             AppState.ItemList => "T\u00e9telek",
             AppState.Summary => "\u00d6sszes\u00edt\u0151",

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -156,9 +156,6 @@
         <DataTemplate x:Key="InvoiceListTemplate">
             <views:InvoiceListView />
         </DataTemplate>
-        <DataTemplate x:Key="InvoiceEditorTemplate">
-            <views:InvoiceEditorView />
-        </DataTemplate>
         <DataTemplate x:Key="HeaderTemplate">
             <views:InvoiceHeaderView />
         </DataTemplate>
@@ -181,7 +178,6 @@
                                           ProductsTemplate="{StaticResource ProductsTemplate}"
                                           DashboardTemplate="{StaticResource DashboardTemplate}"
                                           InvoiceListTemplate="{StaticResource InvoiceListTemplate}"
-                                          InvoiceEditorTemplate="{StaticResource InvoiceEditorTemplate}"
                                           HeaderTemplate="{StaticResource HeaderTemplate}"
                                           ItemListTemplate="{StaticResource ItemListTemplate}"
                                           SummaryTemplate="{StaticResource SummaryTemplate}"


### PR DESCRIPTION
## Summary
- clean up obsolete InvoiceEditor enum and helpers
- drop matching DataTemplate from MainWindow
- update docs

## Testing
- `grep -r "InvoiceEditor" -n | sort` *(shows only view files)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6c5687e4832299d2467f13baaad7