### PR TITLE
Update SaveCommand trigger on validation change

### DIFF
--- a/InvoiceApp.Tests/InvoiceValidationTests.cs
+++ b/InvoiceApp.Tests/InvoiceValidationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using InvoiceApp.Models;
@@ -29,6 +30,47 @@ namespace InvoiceApp.Tests
                     TaxRate = new TaxRate { Percentage = 27m }
                 }) { TaxRatePercentage = 27m }
             };
+            Assert.IsFalse(vm.SaveCommand.CanExecute(null));
+        }
+
+        [TestMethod]
+        public void SaveCommand_ReactsToValidationChanges()
+        {
+            var vm = TestHelpers.CreateInvoiceViewModel();
+            var invoice = new Invoice();
+            vm.SelectedInvoice = invoice;
+            vm.Items = new ObservableCollection<InvoiceItemViewModel>
+            {
+                new InvoiceItemViewModel(new InvoiceItem
+                {
+                    Quantity = 1,
+                    UnitPrice = 10,
+                    ProductId = 1,
+                    TaxRate = new TaxRate { Id = 1, Percentage = 27m },
+                    TaxRateId = 1
+                }) { TaxRatePercentage = 27m }
+            };
+
+            bool canExecuteChanged = false;
+            vm.SaveCommand.CanExecuteChanged += (_, _) => canExecuteChanged = true;
+
+            Assert.IsFalse(vm.SaveCommand.CanExecute(null));
+
+            invoice.Number = "INV-1";
+            invoice.Issuer = "Issuer";
+            invoice.Date = DateTime.Today;
+            invoice.Supplier = new Supplier { Id = 1 };
+            invoice.SupplierId = 1;
+            invoice.PaymentMethod = new PaymentMethod { Id = 1 };
+            invoice.PaymentMethodId = 1;
+
+            Assert.IsTrue(canExecuteChanged);
+            Assert.IsTrue(vm.SaveCommand.CanExecute(null));
+
+            canExecuteChanged = false;
+            invoice.Number = string.Empty;
+
+            Assert.IsTrue(canExecuteChanged);
             Assert.IsFalse(vm.SaveCommand.CanExecute(null));
         }
     }

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -87,6 +87,7 @@ namespace InvoiceApp.ViewModels
         {
             OnPropertyChanged(nameof(ValidationErrors));
             OnPropertyChanged(nameof(HasValidationErrors));
+            ((RelayCommand)SaveCommand).RaiseCanExecuteChanged();
         }
 
         public Invoice? SelectedInvoice


### PR DESCRIPTION
## Summary
- ensure save command reevaluates on invoice validation errors
- test SaveCommand reacts to validation state changes

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_687a791176508322bd54f080a9557542