### PR TITLE
Ensure confirmation before creating new VAT rates

### DIFF
--- a/ViewModels/ProductViewModel.cs
+++ b/ViewModels/ProductViewModel.cs
@@ -195,17 +195,31 @@ namespace InvoiceApp.ViewModels
                 var rate = TaxRates.FirstOrDefault(r => r.Percentage == percent);
                 if (rate == null)
                 {
-                    rate = new TaxRate
+                    var confirmAdd = DialogHelper.ShowConfirmation(
+                        $"Nincs {percent}% áfakulcs. Új áfakulcsot szeretnél létrehozni?",
+                        "Megerősítés");
+                    if (confirmAdd)
                     {
-                        Name = $"ÁFA {percent}%",
-                        Percentage = percent,
-                        EffectiveFrom = DateTime.Today,
-                        Active = true,
-                        DateCreated = DateTime.Now,
-                        DateUpdated = DateTime.Now
-                    };
-                    await _taxRateService.SaveAsync(rate);
-                    TaxRates.Add(rate);
+                        rate = new TaxRate
+                        {
+                            Name = $"ÁFA {percent}%",
+                            Percentage = percent,
+                            EffectiveFrom = DateTime.Today,
+                            Active = true,
+                            DateCreated = DateTime.Now,
+                            DateUpdated = DateTime.Now
+                        };
+                        await _taxRateService.SaveAsync(rate);
+                        TaxRates.Add(rate);
+                    }
+                    else
+                    {
+                        rate = TaxRates.FirstOrDefault(r => r.Id == SelectedProduct.TaxRateId);
+                        if (rate != null)
+                        {
+                            SelectedProduct.TaxRate = rate;
+                        }
+                    }
                 }
                 SelectedProduct.TaxRate = rate;
                 SelectedProduct.TaxRateId = rate.Id;


### PR DESCRIPTION
## Summary
- align VAT rate creation logic by prompting confirmation in `SaveSelectedAsync`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a90f9b3bc83228da5034fd2a59134