### PR TITLE
Implement change tracking across master data views

### DIFF
--- a/ViewModels/PaymentMethodViewModel.cs
+++ b/ViewModels/PaymentMethodViewModel.cs
@@ -23,10 +23,17 @@ namespace InvoiceApp.ViewModels
         }
 
         public PaymentMethodViewModel(IPaymentMethodService service)
-            : base()
+            : base(true)
         {
             _service = service;
+            ClearChanges();
         }
+
+        public bool HasChanges => base.HasChanges;
+
+        public void MarkDirty() => base.MarkDirty();
+
+        public void ClearChanges() => base.ClearChanges();
 
         public async Task LoadAsync()
         {

--- a/ViewModels/ProductGroupViewModel.cs
+++ b/ViewModels/ProductGroupViewModel.cs
@@ -23,10 +23,17 @@ namespace InvoiceApp.ViewModels
         }
 
         public ProductGroupViewModel(IProductGroupService service)
-            : base()
+            : base(true)
         {
             _service = service;
+            ClearChanges();
         }
+
+        public bool HasChanges => base.HasChanges;
+
+        public void MarkDirty() => base.MarkDirty();
+
+        public void ClearChanges() => base.ClearChanges();
 
         public async Task LoadAsync()
         {

--- a/ViewModels/TaxRateViewModel.cs
+++ b/ViewModels/TaxRateViewModel.cs
@@ -23,10 +23,17 @@ namespace InvoiceApp.ViewModels
         }
 
         public TaxRateViewModel(ITaxRateService service)
-            : base()
+            : base(true)
         {
             _service = service;
+            ClearChanges();
         }
+
+        public bool HasChanges => base.HasChanges;
+
+        public void MarkDirty() => base.MarkDirty();
+
+        public void ClearChanges() => base.ClearChanges();
 
         public async Task LoadAsync()
         {

--- a/ViewModels/UnitViewModel.cs
+++ b/ViewModels/UnitViewModel.cs
@@ -23,10 +23,17 @@ namespace InvoiceApp.ViewModels
         }
 
         public UnitViewModel(IUnitService service)
-            : base()
+            : base(true)
         {
             _service = service;
+            ClearChanges();
         }
+
+        public bool HasChanges => base.HasChanges;
+
+        public void MarkDirty() => base.MarkDirty();
+
+        public void ClearChanges() => base.ClearChanges();
 
         public async Task LoadAsync()
         {

--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -23,6 +23,7 @@
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
                   PreviewKeyDown="DataGrid_PreviewKeyDown"
+                  CellEditEnding="DataGrid_CellEditEnding"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/PaymentMethodView.xaml.cs
+++ b/Views/PaymentMethodView.xaml.cs
@@ -27,5 +27,10 @@ namespace InvoiceApp.Views
         {
             DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
+
+        private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+        {
+            _viewModel.MarkDirty();
+        }
     }
 }

--- a/Views/ProductGroupView.xaml
+++ b/Views/ProductGroupView.xaml
@@ -23,6 +23,7 @@
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
                   PreviewKeyDown="DataGrid_PreviewKeyDown"
+                  CellEditEnding="DataGrid_CellEditEnding"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/ProductGroupView.xaml.cs
+++ b/Views/ProductGroupView.xaml.cs
@@ -27,5 +27,10 @@ namespace InvoiceApp.Views
         {
             DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
+
+        private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+        {
+            _viewModel.MarkDirty();
+        }
     }
 }

--- a/Views/TaxRateView.xaml
+++ b/Views/TaxRateView.xaml
@@ -23,6 +23,7 @@
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
                   PreviewKeyDown="DataGrid_PreviewKeyDown"
+                  CellEditEnding="DataGrid_CellEditEnding"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/TaxRateView.xaml.cs
+++ b/Views/TaxRateView.xaml.cs
@@ -27,5 +27,10 @@ namespace InvoiceApp.Views
         {
             DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
+
+        private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+        {
+            _viewModel.MarkDirty();
+        }
     }
 }

--- a/Views/UnitView.xaml
+++ b/Views/UnitView.xaml
@@ -23,6 +23,7 @@
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
                   PreviewKeyDown="DataGrid_PreviewKeyDown"
+                  CellEditEnding="DataGrid_CellEditEnding"
                   Margin="5">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Kód" Binding="{Binding Code, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/UnitView.xaml.cs
+++ b/Views/UnitView.xaml.cs
@@ -27,5 +27,10 @@ namespace InvoiceApp.Views
         {
             DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
         }
+
+        private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+        {
+            _viewModel.MarkDirty();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enable change tracking in Unit, PaymentMethod, ProductGroup and TaxRate view models
- expose `HasChanges`, `MarkDirty` and `ClearChanges` in each view model
- trigger `MarkDirty` in corresponding views after cell edits

## Testing
- `dotnet build --no-restore` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*
- `dotnet test --no-build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9822f3e88322a30aba3cf0cdf2c0