### PR TITLE
Enable change tracking in Product and Supplier view models

### DIFF
--- a/ViewModels/ProductViewModel.cs
+++ b/ViewModels/ProductViewModel.cs
@@ -13,6 +13,7 @@ namespace InvoiceApp.ViewModels
 {
     public class ProductViewModel : MasterDataViewModel<Product>
     {
+        public new RelayCommand SaveCommand { get; }
         private readonly IProductService _service;
         private readonly ITaxRateService _taxRateService;
         private readonly IUnitService _unitService;
@@ -82,7 +83,22 @@ namespace InvoiceApp.ViewModels
             _unitService = unitService;
             _groupService = groupService;
             ClearChanges();
+            SaveCommand = new RelayCommand(async _ =>
+            {
+                if (SelectedProduct != null)
+                {
+                    await SaveItemAsync(SelectedProduct);
+                    AfterSave(SelectedProduct);
+                    ClearChanges();
+                }
+            }, _ => SelectedProduct != null && HasChanges && CanSaveItem(SelectedProduct));
         }
+
+        public bool HasChanges => base.HasChanges;
+
+        public void MarkDirty() => base.MarkDirty();
+
+        public void ClearChanges() => base.ClearChanges();
 
         public async Task LoadAsync()
         {

--- a/ViewModels/SupplierViewModel.cs
+++ b/ViewModels/SupplierViewModel.cs
@@ -9,6 +9,7 @@ namespace InvoiceApp.ViewModels
 {
     public class SupplierViewModel : MasterDataViewModel<Supplier>
     {
+        public new RelayCommand SaveCommand { get; }
         private readonly ISupplierService _service;
         public ObservableCollection<Supplier> Suppliers
         {
@@ -27,7 +28,22 @@ namespace InvoiceApp.ViewModels
         {
             _service = service;
             ClearChanges();
+            SaveCommand = new RelayCommand(async _ =>
+            {
+                if (SelectedSupplier != null)
+                {
+                    await SaveItemAsync(SelectedSupplier);
+                    AfterSave(SelectedSupplier);
+                    ClearChanges();
+                }
+            }, _ => SelectedSupplier != null && HasChanges && CanSaveItem(SelectedSupplier));
         }
+
+        public bool HasChanges => base.HasChanges;
+
+        public void MarkDirty() => base.MarkDirty();
+
+        public void ClearChanges() => base.ClearChanges();
 
         public async Task LoadAsync()
         {


### PR DESCRIPTION
## Summary
- expose change tracking helpers in `SupplierViewModel` and `ProductViewModel`
- customise each Save command so it requires `HasChanges`
- keep views calling `MarkDirty` when a cell edit ends

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a993932a883228235aa79f690809a