### PR TITLE
Introduce status service and bind to status bar

### DIFF
--- a/Docs/AppStateNavigation.md
+++ b/Docs/AppStateNavigation.md
@@ -42,3 +42,5 @@ The invoice editor substates (`Header`, `ItemList`, `Summary`) respond only to *
 ## Deletion confirmations
 
 Every view model that performs a delete operation must show a confirmation dialog before calling the underlying `DeleteAsync` service. Use `DialogHelper.ConfirmDeletion` with a short description of the item being deleted. This ensures users receive consistent prompts across the application.
+
+After a successful deletion, feedback is provided via the application's status bar instead of a modal dialog.

--- a/InvoiceApp.Tests/StatusServiceTests.cs
+++ b/InvoiceApp.Tests/StatusServiceTests.cs
@@ -1,0 +1,26 @@
+using InvoiceApp.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace InvoiceApp.Tests
+{
+    [TestClass]
+    public class StatusServiceTests
+    {
+        [TestMethod]
+        public void Show_SetsMessageAndNotifies()
+        {
+            var service = new StatusService();
+            bool notified = false;
+            service.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(StatusService.Message))
+                    notified = true;
+            };
+
+            service.Show("hello");
+
+            Assert.AreEqual("hello", service.Message);
+            Assert.IsTrue(notified);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A small WPF application demonstrating an MRS (Model–Repository–Service) and 
 - **EF Core Repositories** – For production use, providing robust data access.
 - **ViewModels** – Implementing INotifyPropertyChanged for UI updates.
 - **Commands** – Implementing ICommand for user interactions.
+- **Status Bar Feedback** – Success messages, such as after deletions, appear in the status bar instead of modal dialogs.
 
 ## Documentation
 Detailed navigation information can be found in

--- a/Services/IStatusService.cs
+++ b/Services/IStatusService.cs
@@ -1,0 +1,18 @@
+namespace InvoiceApp.Services
+{
+    /// <summary>
+    /// Provides application-wide status messages for the UI.
+    /// </summary>
+    public interface IStatusService
+    {
+        /// <summary>
+        /// Gets the currently displayed status message.
+        /// </summary>
+        string Message { get; }
+
+        /// <summary>
+        /// Displays a new status message.
+        /// </summary>
+        void Show(string message);
+    }
+}

--- a/Services/StatusService.cs
+++ b/Services/StatusService.cs
@@ -1,0 +1,27 @@
+using InvoiceApp.ViewModels;
+
+namespace InvoiceApp.Services
+{
+    /// <summary>
+    /// Default implementation of <see cref="IStatusService"/>.
+    /// Stores the last shown message and notifies listeners when it changes.
+    /// </summary>
+    public class StatusService : ViewModelBase, IStatusService
+    {
+        private string _message = string.Empty;
+        public string Message
+        {
+            get => _message;
+            private set
+            {
+                _message = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public void Show(string message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/StartupOrchestrator.cs
+++ b/StartupOrchestrator.cs
@@ -75,6 +75,7 @@ namespace InvoiceApp
             services.AddSingleton<IUnitService, UnitService>();
             services.AddSingleton<IProductGroupService, ProductGroupService>();
             services.AddSingleton<ITaxRateService, TaxRateService>();
+            services.AddSingleton<IStatusService, StatusService>();
 
             services.AddSingleton<ViewModels.InvoiceViewModel>();
             services.AddSingleton<ViewModels.ProductViewModel>();

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -23,6 +23,7 @@ namespace InvoiceApp.ViewModels
         private readonly IChangeLogService _logService;
         private readonly SupplierViewModel _supplierViewModel;
         private readonly INavigationService _navigation;
+        private readonly IStatusService _statusService;
         private ObservableCollection<Invoice> _invoices = new();
         private Invoice? _selectedInvoice;
         private string _statusMessage = string.Empty;
@@ -56,6 +57,7 @@ namespace InvoiceApp.ViewModels
 
         private void ShowStatus(string message)
         {
+            _statusService.Show(message);
             StatusMessage = message;
             _statusTimer.Stop();
             _statusTimer.Start();
@@ -283,7 +285,8 @@ namespace InvoiceApp.ViewModels
             IPaymentMethodService paymentService,
             IChangeLogService logService,
             SupplierViewModel supplierViewModel,
-            INavigationService navigation)
+            INavigationService navigation,
+            IStatusService statusService)
         {
             _service = service;
             _itemService = itemService;
@@ -294,10 +297,11 @@ namespace InvoiceApp.ViewModels
             _logService = logService;
             _supplierViewModel = supplierViewModel;
             _navigation = navigation;
+            _statusService = statusService;
 
             Header = new HeaderViewModel(
                 _supplierViewModel,
-                ShowStatus,
+                _statusService.Show,
                 SuggestNextNumberAsync,
                 () => ((RelayCommand)SaveCommand).RaiseCanExecuteChanged(),
                 MarkDirty,
@@ -307,7 +311,7 @@ namespace InvoiceApp.ViewModels
                 _itemService,
                 _productService,
                 _taxRateService,
-                ShowStatus,
+                _statusService,
                 () => ((RelayCommand)SaveCommand).RaiseCanExecuteChanged(),
                 MarkDirty,
                 () => Header.IsGrossCalculation,

--- a/ViewModels/ItemsViewModel.cs
+++ b/ViewModels/ItemsViewModel.cs
@@ -18,7 +18,7 @@ namespace InvoiceApp.ViewModels
         private readonly IInvoiceItemService _itemService;
         private readonly IProductService _productService;
         private readonly ITaxRateService _taxRateService;
-        private readonly Action<string> _showStatus;
+        private readonly IStatusService _statusService;
         private readonly Action _raiseSaveChanged;
         private readonly Action _markDirty;
         private readonly Func<bool> _isGrossFunc;
@@ -41,7 +41,7 @@ namespace InvoiceApp.ViewModels
         public ItemsViewModel(IInvoiceItemService itemService,
             IProductService productService,
             ITaxRateService taxRateService,
-            Action<string> showStatus,
+            IStatusService statusService,
             Action raiseSaveChanged,
             Action markDirty,
             Func<bool> isGrossFunc,
@@ -50,7 +50,7 @@ namespace InvoiceApp.ViewModels
             _itemService = itemService;
             _productService = productService;
             _taxRateService = taxRateService;
-            _showStatus = showStatus;
+            _statusService = statusService;
             _raiseSaveChanged = raiseSaveChanged;
             _markDirty = markDirty;
             _isGrossFunc = isGrossFunc;
@@ -62,7 +62,7 @@ namespace InvoiceApp.ViewModels
                 if (obj is InvoiceItemViewModel item && DialogHelper.ConfirmDeletion("tételt"))
                 {
                     RemoveItem(item);
-                    _showStatus("Tétel törölve.");
+                    _statusService.Show("Tétel törölve.");
                 }
             });
             SaveItemCommand = new RelayCommand(async obj =>
@@ -231,7 +231,7 @@ namespace InvoiceApp.ViewModels
             }
 
             await _itemService.SaveAsync(item.Item);
-            _showStatus($"Tétel mentve. ({DateTime.Now:g})");
+            _statusService.Show($"Tétel mentve. ({DateTime.Now:g})");
         }
 
         private void Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/ViewModels/PaymentMethodViewModel.cs
+++ b/ViewModels/PaymentMethodViewModel.cs
@@ -10,6 +10,7 @@ namespace InvoiceApp.ViewModels
     public class PaymentMethodViewModel : MasterDataViewModel<PaymentMethod>, IHasChanges
     {
         private readonly IPaymentMethodService _service;
+        private readonly IStatusService _statusService;
         public ObservableCollection<PaymentMethod> Methods
         {
             get => Items;
@@ -22,10 +23,12 @@ namespace InvoiceApp.ViewModels
             set => SelectedItem = value;
         }
 
-        public PaymentMethodViewModel(IPaymentMethodService service)
+        public PaymentMethodViewModel(IPaymentMethodService service,
+            IStatusService statusService)
             : base(true)
         {
             _service = service;
+            _statusService = statusService;
             ClearChanges();
         }
 
@@ -48,7 +51,7 @@ namespace InvoiceApp.ViewModels
             if (!DialogHelper.ConfirmDeletion("fizetési módot"))
                 return false;
             await _service.DeleteAsync(method.Id);
-            DialogHelper.ShowInfo("Törlés sikeres.");
+            _statusService.Show("Törlés sikeres.");
             return true;
         }
 

--- a/ViewModels/ProductGroupViewModel.cs
+++ b/ViewModels/ProductGroupViewModel.cs
@@ -10,6 +10,7 @@ namespace InvoiceApp.ViewModels
     public class ProductGroupViewModel : MasterDataViewModel<ProductGroup>, IHasChanges
     {
         private readonly IProductGroupService _service;
+        private readonly IStatusService _statusService;
         public ObservableCollection<ProductGroup> Groups
         {
             get => Items;
@@ -22,10 +23,12 @@ namespace InvoiceApp.ViewModels
             set => SelectedItem = value;
         }
 
-        public ProductGroupViewModel(IProductGroupService service)
+        public ProductGroupViewModel(IProductGroupService service,
+            IStatusService statusService)
             : base(true)
         {
             _service = service;
+            _statusService = statusService;
             ClearChanges();
         }
 
@@ -48,7 +51,7 @@ namespace InvoiceApp.ViewModels
             if (!DialogHelper.ConfirmDeletion("termékcsoportot"))
                 return false;
             await _service.DeleteAsync(group.Id);
-            DialogHelper.ShowInfo("Törlés sikeres.");
+            _statusService.Show("Törlés sikeres.");
             return true;
         }
 

--- a/ViewModels/ProductViewModel.cs
+++ b/ViewModels/ProductViewModel.cs
@@ -18,6 +18,7 @@ namespace InvoiceApp.ViewModels
         private readonly ITaxRateService _taxRateService;
         private readonly IUnitService _unitService;
         private readonly IProductGroupService _groupService;
+        private readonly IStatusService _statusService;
         private ObservableCollection<TaxRate> _taxRates = new();
         private ObservableCollection<Unit> _units = new();
         private ObservableCollection<ProductGroup> _groups = new();
@@ -75,13 +76,15 @@ namespace InvoiceApp.ViewModels
         public ProductViewModel(IProductService service,
                                 ITaxRateService taxRateService,
                                 IUnitService unitService,
-                                IProductGroupService groupService)
+                                IProductGroupService groupService,
+                                IStatusService statusService)
             : base(true)
         {
             _service = service;
             _taxRateService = taxRateService;
             _unitService = unitService;
             _groupService = groupService;
+            _statusService = statusService;
             ClearChanges();
             SaveCommand = new RelayCommand(async _ =>
             {
@@ -154,7 +157,7 @@ namespace InvoiceApp.ViewModels
             if (!DialogHelper.ConfirmDeletion("terméket"))
                 return false;
             await _service.DeleteAsync(product.Id);
-            DialogHelper.ShowInfo("Törlés sikeres.");
+            _statusService.Show("Törlés sikeres.");
             return true;
         }
 

--- a/ViewModels/SupplierViewModel.cs
+++ b/ViewModels/SupplierViewModel.cs
@@ -11,6 +11,7 @@ namespace InvoiceApp.ViewModels
     {
         public new RelayCommand SaveCommand { get; }
         private readonly ISupplierService _service;
+        private readonly IStatusService _statusService;
         public ObservableCollection<Supplier> Suppliers
         {
             get => Items;
@@ -23,10 +24,12 @@ namespace InvoiceApp.ViewModels
             set => SelectedItem = value;
         }
 
-        public SupplierViewModel(ISupplierService service)
+        public SupplierViewModel(ISupplierService service,
+            IStatusService statusService)
             : base(true)
         {
             _service = service;
+            _statusService = statusService;
             ClearChanges();
             SaveCommand = new RelayCommand(async _ =>
             {
@@ -66,7 +69,7 @@ namespace InvoiceApp.ViewModels
             if (!DialogHelper.ConfirmDeletion("szállítót"))
                 return false;
             await _service.DeleteAsync(supplier.Id);
-            DialogHelper.ShowInfo("Törlés sikeres.");
+            _statusService.Show("Törlés sikeres.");
             return true;
         }
 

--- a/ViewModels/TaxRateViewModel.cs
+++ b/ViewModels/TaxRateViewModel.cs
@@ -10,6 +10,7 @@ namespace InvoiceApp.ViewModels
     public class TaxRateViewModel : MasterDataViewModel<TaxRate>, IHasChanges
     {
         private readonly ITaxRateService _service;
+        private readonly IStatusService _statusService;
         public ObservableCollection<TaxRate> Rates
         {
             get => Items;
@@ -22,10 +23,12 @@ namespace InvoiceApp.ViewModels
             set => SelectedItem = value;
         }
 
-        public TaxRateViewModel(ITaxRateService service)
+        public TaxRateViewModel(ITaxRateService service,
+            IStatusService statusService)
             : base(true)
         {
             _service = service;
+            _statusService = statusService;
             ClearChanges();
         }
 
@@ -48,7 +51,7 @@ namespace InvoiceApp.ViewModels
             if (!DialogHelper.ConfirmDeletion("áfakulcsot"))
                 return false;
             await _service.DeleteAsync(rate.Id);
-            DialogHelper.ShowInfo("Törlés sikeres.");
+            _statusService.Show("Törlés sikeres.");
             return true;
         }
 

--- a/ViewModels/UnitViewModel.cs
+++ b/ViewModels/UnitViewModel.cs
@@ -10,6 +10,7 @@ namespace InvoiceApp.ViewModels
     public class UnitViewModel : MasterDataViewModel<Unit>, IHasChanges
     {
         private readonly IUnitService _service;
+        private readonly IStatusService _statusService;
         public ObservableCollection<Unit> Units
         {
             get => Items;
@@ -22,10 +23,12 @@ namespace InvoiceApp.ViewModels
             set => SelectedItem = value;
         }
 
-        public UnitViewModel(IUnitService service)
+        public UnitViewModel(IUnitService service,
+            IStatusService statusService)
             : base(true)
         {
             _service = service;
+            _statusService = statusService;
             ClearChanges();
         }
 
@@ -48,7 +51,7 @@ namespace InvoiceApp.ViewModels
             if (!DialogHelper.ConfirmDeletion("mértékegységet"))
                 return false;
             await _service.DeleteAsync(unit.Id);
-            DialogHelper.ShowInfo("Törlés sikeres.");
+            _statusService.Show("Törlés sikeres.");
             return true;
         }
 

--- a/ViewModels/ViewModelLocator.cs
+++ b/ViewModels/ViewModelLocator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
+using InvoiceApp.Services;
 
 namespace InvoiceApp.ViewModels
 {
@@ -20,5 +21,6 @@ namespace InvoiceApp.ViewModels
         public UnitViewModel UnitViewModel => ServiceProvider.GetRequiredService<UnitViewModel>();
         public ProductGroupViewModel ProductGroupViewModel => ServiceProvider.GetRequiredService<ProductGroupViewModel>();
         public TaxRateViewModel TaxRateViewModel => ServiceProvider.GetRequiredService<TaxRateViewModel>();
+        public IStatusService StatusService => ServiceProvider.GetRequiredService<IStatusService>();
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -207,7 +207,7 @@
                    Margin="4" />
         <StatusBar DockPanel.Dock="Bottom">
             <TextBlock Text="{Binding CurrentStateDescription}" Margin="0,0,10,0"/>
-            <TextBlock Text="{Binding InvoiceViewModel.StatusMessage}" />
+            <TextBlock Text="{Binding Source={StaticResource ViewModelLocator}, Path=StatusService.Message}" />
         </StatusBar>
         <ContentControl x:Name="StateRegion"
                         Content="{Binding CurrentState}"


### PR DESCRIPTION
## Summary
- add new `IStatusService` and `StatusService`
- register `StatusService` in `StartupOrchestrator`
- expose service via `ViewModelLocator`
- bind MainWindow status bar to service
- update deletion logic in ViewModels to use status service
- document new status bar feedback
- add simple unit test for `StatusService`

## Testing
- `dotnet build InvoiceApp.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet test InvoiceApp.Tests/InvoiceApp.Tests.csproj --no-build` *(fails: argument invalid due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_687aa328c21c83228b6159a870a0d922