### PR TITLE
Add gross input support in ProductView

### DIFF
--- a/InvoiceApp.Tests/ProductViewModelTests.cs
+++ b/InvoiceApp.Tests/ProductViewModelTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.ObjectModel;
+using InvoiceApp.ViewModels;
+using InvoiceApp.Models;
+using InvoiceApp.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace InvoiceApp.Tests
+{
+    [TestClass]
+    public class ProductViewModelTests
+    {
+        private static ProductViewModel CreateVm()
+        {
+            var stub = new StubService<object>();
+            return new ProductViewModel(stub, stub, stub, stub, new StatusService());
+        }
+
+        [TestMethod]
+        public void NetChange_UpdatesGross_WhenNetMode()
+        {
+            var vm = CreateVm();
+            var rate = new TaxRate { Id = 1, Percentage = 27m };
+            vm.TaxRates = new ObservableCollection<TaxRate> { rate };
+            var product = new Product { TaxRate = rate, TaxRateId = rate.Id };
+            vm.Products = new ObservableCollection<Product> { product };
+            vm.SelectedProduct = product;
+            vm.IsGrossInput = false;
+
+            product.Net = 100m;
+
+            Assert.AreEqual(127m, product.Gross);
+        }
+
+        [TestMethod]
+        public void GrossChange_UpdatesNet_WhenGrossMode()
+        {
+            var vm = CreateVm();
+            var rate = new TaxRate { Id = 1, Percentage = 27m };
+            vm.TaxRates = new ObservableCollection<TaxRate> { rate };
+            var product = new Product { TaxRate = rate, TaxRateId = rate.Id };
+            vm.Products = new ObservableCollection<Product> { product };
+            vm.SelectedProduct = product;
+            vm.IsGrossInput = true;
+
+            product.Gross = 127m;
+
+            Assert.AreEqual(100m, product.Net);
+        }
+    }
+}

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -26,6 +26,21 @@
                     Command="{Binding DataContext.ShowProductGroupsCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
             <Button Content="Egységek" Margin="4,0,0,0"
                     Command="{Binding DataContext.ShowUnitsCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+            <CheckBox Content="Bruttó?" Margin="8,0,0,0"
+                      IsChecked="{Binding IsGrossInput}"
+                      ToolTip="Bejelölve a bruttó érték szerkeszthető, egyébként számított." />
+            <TextBlock Margin="8,0,0,0">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Text" Value="Bruttó érték számított" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsGrossInput}" Value="True">
+                                <Setter Property="Text" Value="Bruttó érték szerkeszthető" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
         </StackPanel>
         <DataGrid x:Name="DataGrid"
                   Grid.Row="1"


### PR DESCRIPTION
## Summary
- add `IsGrossInput` to `ProductViewModel` for editing mode
- sync net & gross values on property changes
- respect chosen mode when saving
- label in `ProductView` explains gross field behaviour
- test calculation updates for net→gross and gross→net

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa5a3c44c83228f15cc248bd565a7