### PR TITLE
Handle Up key at first row

### DIFF
--- a/InvoiceApp.Tests/UnitViewModelTests.cs
+++ b/InvoiceApp.Tests/UnitViewModelTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.ObjectModel;
+using InvoiceApp.Models;
+using InvoiceApp.Services;
+using InvoiceApp.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace InvoiceApp.Tests
+{
+    [TestClass]
+    public class UnitViewModelTests
+    {
+        [TestMethod]
+        public void SelectPreviousUnit_AtTop_ShowsConfirmation()
+        {
+            var vm = new UnitViewModel(new StubService<Unit>(), new StatusService());
+            vm.Units = new ObservableCollection<Unit>
+            {
+                new Unit { Id = 1, Name = "db" }
+            };
+            vm.SelectedUnit = vm.Units[0];
+
+            bool confirmed = false;
+            DialogHelper.ConfirmationHandler = (m, t) => { confirmed = true; return false; };
+            try
+            {
+                vm.SelectPreviousUnit();
+            }
+            finally
+            {
+                DialogHelper.ConfirmationHandler = null;
+            }
+
+            Assert.IsTrue(confirmed);
+        }
+
+        [TestMethod]
+        public void SelectPreviousUnit_AtTop_AddsUnit_WhenConfirmed()
+        {
+            var vm = new UnitViewModel(new StubService<Unit>(), new StatusService());
+            vm.Units = new ObservableCollection<Unit>
+            {
+                new Unit { Id = 1, Name = "db" }
+            };
+            vm.SelectedUnit = vm.Units[0];
+
+            DialogHelper.ConfirmationHandler = (m, t) => true;
+            try
+            {
+                vm.SelectPreviousUnit();
+            }
+            finally
+            {
+                DialogHelper.ConfirmationHandler = null;
+            }
+
+            Assert.AreEqual(2, vm.Units.Count);
+        }
+    }
+}

--- a/Views/PaymentMethodView.xaml.cs
+++ b/Views/PaymentMethodView.xaml.cs
@@ -25,7 +25,15 @@ namespace InvoiceApp.Views
 
         private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            if (e.Key == Key.Up && sender is DataGrid grid && grid.SelectedIndex == 0)
+            {
+                ViewModel.SelectPreviousMethod();
+                e.Handled = true;
+            }
+            else
+            {
+                DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            }
         }
 
         private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)

--- a/Views/ProductGroupView.xaml.cs
+++ b/Views/ProductGroupView.xaml.cs
@@ -25,7 +25,15 @@ namespace InvoiceApp.Views
 
         private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            if (e.Key == Key.Up && sender is DataGrid grid && grid.SelectedIndex == 0)
+            {
+                ViewModel.SelectPreviousGroup();
+                e.Handled = true;
+            }
+            else
+            {
+                DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            }
         }
 
         private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)

--- a/Views/ProductView.xaml.cs
+++ b/Views/ProductView.xaml.cs
@@ -33,7 +33,15 @@ namespace InvoiceApp.Views
 
         private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            if (e.Key == Key.Up && sender is DataGrid grid && grid.SelectedIndex == 0)
+            {
+                ViewModel.SelectPreviousProduct();
+                e.Handled = true;
+            }
+            else
+            {
+                DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            }
         }
     }
 }

--- a/Views/SupplierView.xaml.cs
+++ b/Views/SupplierView.xaml.cs
@@ -33,7 +33,15 @@ namespace InvoiceApp.Views
 
         private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            if (e.Key == Key.Up && sender is DataGrid grid && grid.SelectedIndex == 0)
+            {
+                ViewModel.SelectPreviousSupplier();
+                e.Handled = true;
+            }
+            else
+            {
+                DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            }
         }
     }
 }

--- a/Views/TaxRateView.xaml.cs
+++ b/Views/TaxRateView.xaml.cs
@@ -25,7 +25,15 @@ namespace InvoiceApp.Views
 
         private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            if (e.Key == Key.Up && sender is DataGrid grid && grid.SelectedIndex == 0)
+            {
+                ViewModel.SelectPreviousRate();
+                e.Handled = true;
+            }
+            else
+            {
+                DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            }
         }
 
         private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)

--- a/Views/UnitView.xaml.cs
+++ b/Views/UnitView.xaml.cs
@@ -25,7 +25,15 @@ namespace InvoiceApp.Views
 
         private void DataGrid_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            if (e.Key == Key.Up && sender is DataGrid grid && grid.SelectedIndex == 0)
+            {
+                ViewModel.SelectPreviousUnit();
+                e.Handled = true;
+            }
+            else
+            {
+                DataGridFocusBehavior.OnPreviewKeyDown(sender, e);
+            }
         }
 
         private void DataGrid_CellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)


### PR DESCRIPTION
## Summary
- enable selection rollback from the first row of each list DataGrid
- add Up key behavior for Units, Payment Methods, Products, Product Groups, Suppliers and Tax Rates
- test `UnitViewModel.SelectPreviousUnit` adds new item when confirmed

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop". The SDK 'Microsoft.NET.Sdk.WindowsDesktop' specified could not be found.)*

------
https://chatgpt.com/codex/tasks/task_e_687aa738cf1c8322a47be7aab01b6a31