### PR TITLE
Remove global Delete binding

### DIFF
--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -717,6 +717,9 @@ namespace InvoiceApp.ViewModels
         /// </summary>
         public void DeleteCurrentInvoice()
         {
+            if (_navigation.CurrentState != AppState.InvoiceList)
+                return;
+
             if (SelectedInvoice != null && RemoveInvoiceCommand.CanExecute(SelectedInvoice))
             {
                 RemoveInvoiceCommand.Execute(SelectedInvoice);

--- a/Views/InvoiceListView.xaml
+++ b/Views/InvoiceListView.xaml
@@ -5,6 +5,9 @@
              xmlns:views="clr-namespace:InvoiceApp.Views"
              xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
              MinHeight="300" MinWidth="500">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Delete" Command="{Binding DataContext.DeleteInvoiceCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
+    </UserControl.InputBindings>
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </UserControl.Resources>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -189,7 +189,6 @@
         <KeyBinding Key="Down" Command="{Binding NavigateDownCommand}"/>
         <KeyBinding Key="Enter" Command="{Binding EnterCommand}"/>
         <KeyBinding Key="Escape" Command="{Binding BackCommand}"/>
-        <KeyBinding Key="Delete" Command="{Binding DeleteInvoiceCommand}"/>
         <KeyBinding Key="Insert" Command="{Binding InvoiceViewModel.NewInvoiceCommand}"/>
         <KeyBinding Key="N" Modifiers="Control+Shift" Command="{Binding InvoiceViewModel.SaveAndNewCommand}"/>
         <KeyBinding Key="F1" Command="{Binding ShowDashboardCommand}"/>


### PR DESCRIPTION
## Summary
- prevent Delete command from being globally handled in MainWindow
- bind Delete key locally in `InvoiceListView`
- only delete invoices if currently viewing the invoice list

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa85e80608322911034a377152528