### PR TITLE
Fix PaymentMethodView binding

### DIFF
--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -28,7 +28,7 @@
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
                 <DataGridTextColumn Header="Határidő"
-                                      Binding="{Binding DueInDays, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}}"
+                                      Binding="{Binding DueInDays, UpdateSourceTrigger=PropertyChanged}"
                                       ElementStyle="{StaticResource RightAlignedCellStyle}" />
             </DataGrid.Columns>
         </DataGrid>


### PR DESCRIPTION
## Summary
- remove `StringFormat` from the DueInDays column binding

## Testing
- `xmllint --noout Views/PaymentMethodView.xaml`

------
https://chatgpt.com/codex/tasks/task_e_687aac23a32083229216cf6d2326ec5d