### PR TITLE
Implement AddSupplier for compilation

### DIFF
--- a/ViewModels/SupplierViewModel.cs
+++ b/ViewModels/SupplierViewModel.cs
@@ -54,6 +54,12 @@ namespace InvoiceApp.ViewModels
             Suppliers = new ObservableCollection<Supplier>(items);
         }
 
+        public Supplier AddSupplier()
+        {
+            AddCommand.Execute(null);
+            return SelectedSupplier!;
+        }
+
         protected override Supplier CreateNewItem()
         {
             return new Supplier


### PR DESCRIPTION
## Summary
- implement missing AddSupplier method in `SupplierViewModel`

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_687aaf5c0cec8322ac37484335eef8c2