### PR TITLE
Add F2 shortcut to bring MainWindow

### DIFF
--- a/Docs/AppStateNavigation.md
+++ b/Docs/AppStateNavigation.md
@@ -26,6 +26,7 @@ Global keyboard shortcuts are mapped as follows:
 | Key | Action |
 |-----|-------|
 | `F1` | Open Dashboard |
+| `F2` | Open Main window |
 | `F4` | Open Products view |
 | `F5` | Open Product groups |
 | `F6` | Open Suppliers |

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -35,6 +35,7 @@ namespace InvoiceApp.ViewModels
             MenuItems = new ObservableCollection<DashboardMenuItem>
             {
                 new DashboardMenuItem("F1", "Vezérlőpult", main.ShowDashboardCommand),
+                new DashboardMenuItem("F2", "Főablak", main.ShowMainWindowCommand),
                 new DashboardMenuItem("F4", "Termékek", main.ShowProductsCommand),
                 new DashboardMenuItem("F5", "Termékcsoportok", main.ShowProductGroupsCommand),
                 new DashboardMenuItem("F6", "Szállítók", main.ShowSuppliersCommand),

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -74,6 +74,7 @@ namespace InvoiceApp.ViewModels
         public RelayCommand ShowTaxRatesCommand { get; }
         public RelayCommand ShowUnitsCommand { get; }
         public RelayCommand ShowProductsCommand { get; }
+        public RelayCommand ShowMainWindowCommand { get; }
         public RelayCommand ShowDashboardCommand { get; }
         public RelayCommand SwitchPaymentMethodsCommand { get; }
         public RelayCommand SwitchSuppliersCommand { get; }
@@ -165,6 +166,7 @@ namespace InvoiceApp.ViewModels
             ShowTaxRatesCommand = new RelayCommand(_ => _navigation.Push(AppState.TaxRates));
             ShowUnitsCommand = new RelayCommand(_ => _navigation.Push(AppState.Units));
             ShowProductsCommand = new RelayCommand(_ => _navigation.Push(AppState.Products));
+            ShowMainWindowCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.MainWindow));
             ShowDashboardCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Dashboard));
             SwitchPaymentMethodsCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.PaymentMethods));
             SwitchSuppliersCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Suppliers));

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -188,6 +188,7 @@
         <KeyBinding Key="Insert" Command="{Binding InvoiceViewModel.NewInvoiceCommand}"/>
         <KeyBinding Key="N" Modifiers="Control+Shift" Command="{Binding InvoiceViewModel.SaveAndNewCommand}"/>
         <KeyBinding Key="F1" Command="{Binding ShowDashboardCommand}"/>
+        <KeyBinding Key="F2" Command="{Binding ShowMainWindowCommand}"/>
         <KeyBinding Key="F4" Command="{Binding ShowProductsCommand}"/>
         <KeyBinding Key="F5" Command="{Binding ShowProductGroupsCommand}"/>
         <KeyBinding Key="F6" Command="{Binding ShowSuppliersCommand}"/>


### PR DESCRIPTION
## Summary
- add ShowMainWindowCommand to MainViewModel
- bind F2 key to the new command in the main window
- list main window hotkey in dashboard menu
- document F2 in app state navigation guide

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_687ac47533788322b85086bb8525ea7f