### PR TITLE
Centralize Insert key handling via StateCommand

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -5,6 +5,7 @@ using InvoiceApp.Services;
 using InvoiceApp;
 using Microsoft.Extensions.DependencyInjection;
 using System.Windows;
+using System.Windows.Input;
 
 namespace InvoiceApp.ViewModels
 {
@@ -82,6 +83,7 @@ namespace InvoiceApp.ViewModels
         public RelayCommand SwitchTaxRatesCommand { get; }
         public RelayCommand SwitchUnitsCommand { get; }
         public RelayCommand SwitchProductsCommand { get; }
+        public ICommand StateAddCommand { get; }
 
         public MainViewModel(INavigationService navigation,
                              InvoiceViewModel invoiceViewModel,
@@ -94,6 +96,8 @@ namespace InvoiceApp.ViewModels
             _currentStateDescription = _current.GetDescription();
             UpdateBreadcrumb();
             _navigation.StateChanged += OnStateChanged;
+
+            StateAddCommand = new StateCommand(_navigation, ((App)Application.Current).Services);
 
             BackCommand = new RelayCommand(_ =>
             {

--- a/ViewModels/StateCommand.cs
+++ b/ViewModels/StateCommand.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using InvoiceApp.Models;
+using InvoiceApp.Services;
+
+namespace InvoiceApp.ViewModels
+{
+    /// <summary>
+    /// Command that dispatches the Insert key to the appropriate "add" command
+    /// based on the current <see cref="AppState"/>.
+    /// </summary>
+    public sealed class StateCommand : ICommand
+    {
+        private readonly INavigationService _navigation;
+        private readonly IServiceProvider _provider;
+
+        public StateCommand(INavigationService navigation, IServiceProvider provider)
+        {
+            _navigation = navigation;
+            _provider = provider;
+        }
+
+        public event EventHandler? CanExecuteChanged;
+
+        public bool CanExecute(object? parameter) => true;
+
+        public void Execute(object? parameter)
+        {
+            var state = _navigation.CurrentState;
+            switch (state)
+            {
+                case AppState.MainWindow:
+                case AppState.Dashboard:
+                    _provider.GetRequiredService<InvoiceViewModel>().NewInvoiceCommand.Execute(null);
+                    break;
+                case AppState.ItemList:
+                    _provider.GetRequiredService<InvoiceViewModel>().AddItemCommand.Execute(null);
+                    break;
+                case AppState.Products:
+                    _provider.GetRequiredService<ProductViewModel>().AddCommand.Execute(null);
+                    break;
+                case AppState.ProductGroups:
+                    _provider.GetRequiredService<ProductGroupViewModel>().AddCommand.Execute(null);
+                    break;
+                case AppState.Suppliers:
+                    _provider.GetRequiredService<SupplierViewModel>().AddCommand.Execute(null);
+                    break;
+                case AppState.TaxRates:
+                    _provider.GetRequiredService<TaxRateViewModel>().AddCommand.Execute(null);
+                    break;
+                case AppState.Units:
+                    _provider.GetRequiredService<UnitViewModel>().AddCommand.Execute(null);
+                    break;
+                case AppState.PaymentMethods:
+                    _provider.GetRequiredService<PaymentMethodViewModel>().AddCommand.Execute(null);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/Views/InvoiceItemDataGrid.xaml
+++ b/Views/InvoiceItemDataGrid.xaml
@@ -24,7 +24,6 @@
             <KeyBinding Key="Up" Command="{Binding ItemsUpCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <KeyBinding Key="Down" Command="{Binding ItemsDownCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <KeyBinding Key="Escape" Command="{Binding ItemsEscapeCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
-            <KeyBinding Key="Insert" Command="{Binding AddItemCommand}"/>
             <KeyBinding Key="Delete" Command="{Binding RemoveItemCommand}" CommandParameter="{Binding SelectedItem}"/>
         </DataGrid.InputBindings>
         <DataGrid.Columns>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -185,7 +185,7 @@
         <KeyBinding Key="Down" Command="{Binding NavigateDownCommand}"/>
         <KeyBinding Key="Enter" Command="{Binding EnterCommand}"/>
         <KeyBinding Key="Escape" Command="{Binding BackCommand}"/>
-        <KeyBinding Key="Insert" Command="{Binding InvoiceViewModel.NewInvoiceCommand}"/>
+        <KeyBinding Key="Insert" Command="{Binding StateAddCommand}"/>
         <KeyBinding Key="N" Modifiers="Control+Shift" Command="{Binding InvoiceViewModel.SaveAndNewCommand}"/>
         <KeyBinding Key="F1" Command="{Binding ShowDashboardCommand}"/>
         <KeyBinding Key="F2" Command="{Binding ShowMainWindowCommand}"/>

--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -8,7 +8,6 @@
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
     <UserControl.InputBindings>
-        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
     <Grid>

--- a/Views/ProductGroupView.xaml
+++ b/Views/ProductGroupView.xaml
@@ -8,7 +8,6 @@
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
     <UserControl.InputBindings>
-        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
     <Grid>

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -8,7 +8,6 @@
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
     <UserControl.InputBindings>
-        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
     <Grid>

--- a/Views/SupplierView.xaml
+++ b/Views/SupplierView.xaml
@@ -8,7 +8,6 @@
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
     <UserControl.InputBindings>
-        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
     <Grid>

--- a/Views/TaxRateView.xaml
+++ b/Views/TaxRateView.xaml
@@ -8,7 +8,6 @@
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
     <UserControl.InputBindings>
-        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
     <Grid>

--- a/Views/UnitView.xaml
+++ b/Views/UnitView.xaml
@@ -8,7 +8,6 @@
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
     <UserControl.InputBindings>
-        <KeyBinding Key="Insert" Command="{Binding AddCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
     <Grid>


### PR DESCRIPTION
## Summary
- implement `StateCommand` to route Insert key presses based on `AppState`
- expose `StateAddCommand` from `MainViewModel`
- bind Insert key in `MainWindow.xaml` to the new command
- drop local Insert bindings from entity views

## Testing
- `dotnet format InvoiceApp.sln --verify-no-changes`

------
https://chatgpt.com/codex/tasks/task_e_687ac8da17788322adb964a97260a262