### PR TITLE
Add service-level business rule validations

### DIFF
--- a/Services/IInvoiceService.cs
+++ b/Services/IInvoiceService.cs
@@ -15,6 +15,7 @@ namespace InvoiceApp.Services
         Task SaveAsync(Invoice invoice);
         Task SaveInvoiceWithItemsAsync(Invoice invoice, IEnumerable<InvoiceItem> items);
         Task DeleteAsync(int id);
+        Task<string> GetNextNumberAsync(int supplierId);
         bool IsValid(Invoice invoice);
     }
 }

--- a/Services/InvoiceItemService.cs
+++ b/Services/InvoiceItemService.cs
@@ -3,15 +3,46 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using InvoiceApp.Models;
 using InvoiceApp.Repositories;
+using InvoiceApp.DTOs;
+using InvoiceApp.Mappers;
+using Microsoft.EntityFrameworkCore;
+using InvoiceApp.Data;
+using FluentValidation;
 using Serilog;
 
 namespace InvoiceApp.Services
 {
     public class InvoiceItemService : BaseService<InvoiceItem>, IInvoiceItemService
     {
-        public InvoiceItemService(IInvoiceItemRepository repository, IChangeLogService logService)
+        private readonly IValidator<InvoiceItemDto> _validator;
+        private readonly IDbContextFactory<InvoiceContext> _contextFactory;
+
+        public InvoiceItemService(
+            IInvoiceItemRepository repository,
+            IChangeLogService logService,
+            IValidator<InvoiceItemDto> validator,
+            IDbContextFactory<InvoiceContext> contextFactory)
             : base(repository, logService)
         {
+            _validator = validator;
+            _contextFactory = contextFactory;
+        }
+
+        protected override async Task ValidateAsync(InvoiceItem entity)
+        {
+            await _validator.ValidateAndThrowAsync(entity.ToDto());
+
+            using var ctx = _contextFactory.CreateDbContext();
+            var productExists = await ctx.Products.AnyAsync(p => p.Id == entity.ProductId);
+            if (!productExists)
+            {
+                throw new BusinessRuleViolationException("Invalid product reference.");
+            }
+            var rateExists = await ctx.TaxRates.AnyAsync(t => t.Id == entity.TaxRateId);
+            if (!rateExists)
+            {
+                throw new BusinessRuleViolationException("Invalid tax rate reference.");
+            }
         }
 
         // CRUD methods provided by BaseService

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -50,6 +50,32 @@ namespace InvoiceApp.Services
             return _repository.GetLatestForSupplierAsync(supplierId);
         }
 
+        public async Task<string> GetNextNumberAsync(int supplierId)
+        {
+            Log.Debug("InvoiceService.GetNextNumberAsync called with {SupplierId}", supplierId);
+            var latest = await GetLatestForSupplierAsync(supplierId);
+            return IncrementNumber(latest?.Number);
+        }
+
+        private static string IncrementNumber(string? lastNumber)
+        {
+            if (string.IsNullOrWhiteSpace(lastNumber)) return "1";
+
+            var digits = new string(lastNumber.Reverse().TakeWhile(char.IsDigit).Reverse().ToArray());
+            if (digits.Length > 0 && int.TryParse(digits, out var n))
+            {
+                var prefix = lastNumber.Substring(0, lastNumber.Length - digits.Length);
+                return prefix + (n + 1).ToString($"D{digits.Length}");
+            }
+
+            if (int.TryParse(lastNumber, out var value))
+            {
+                return (value + 1).ToString();
+            }
+
+            return lastNumber;
+        }
+
         public Task<Invoice?> GetLatestAsync()
         {
             Log.Debug("InvoiceService.GetLatestAsync called");

--- a/Services/ProductGroupService.cs
+++ b/Services/ProductGroupService.cs
@@ -3,17 +3,54 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using InvoiceApp.Models;
 using InvoiceApp.Repositories;
+using InvoiceApp.DTOs;
+using InvoiceApp.Mappers;
+using Microsoft.EntityFrameworkCore;
+using InvoiceApp.Data;
+using FluentValidation;
 using Serilog;
 
 namespace InvoiceApp.Services
 {
     public class ProductGroupService : BaseService<ProductGroup>, IProductGroupService
     {
-        public ProductGroupService(IProductGroupRepository repository, IChangeLogService logService)
+        private readonly IValidator<ProductGroupDto> _validator;
+        private readonly IDbContextFactory<InvoiceContext> _contextFactory;
+
+        public ProductGroupService(
+            IProductGroupRepository repository,
+            IChangeLogService logService,
+            IValidator<ProductGroupDto> validator,
+            IDbContextFactory<InvoiceContext> contextFactory)
             : base(repository, logService)
         {
+            _validator = validator;
+            _contextFactory = contextFactory;
         }
 
-        // CRUD operations handled by BaseService
+        protected override async Task ValidateAsync(ProductGroup entity)
+        {
+            await _validator.ValidateAndThrowAsync(entity.ToDto());
+
+            using var ctx = _contextFactory.CreateDbContext();
+            var nameExists = await ctx.ProductGroups
+                .AnyAsync(g => g.Id != entity.Id && g.Name.ToLower() == entity.Name.ToLower());
+            if (nameExists)
+            {
+                throw new BusinessRuleViolationException($"Product group '{entity.Name}' already exists.");
+            }
+        }
+
+        public override async Task DeleteAsync(int id)
+        {
+            using var ctx = _contextFactory.CreateDbContext();
+            var used = await ctx.Products.AnyAsync(p => p.ProductGroupId == id);
+            if (used)
+            {
+                throw new BusinessRuleViolationException("Product group is referenced by products and cannot be deleted.");
+            }
+
+            await base.DeleteAsync(id);
+        }
     }
 }

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -3,19 +3,71 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using InvoiceApp.Models;
 using InvoiceApp.Repositories;
+using InvoiceApp.DTOs;
+using InvoiceApp.Mappers;
+using Microsoft.EntityFrameworkCore;
+using InvoiceApp.Data;
+using FluentValidation;
 using Serilog;
 
 namespace InvoiceApp.Services
 {
     public class ProductService : BaseService<Product>, IProductService
     {
-        public ProductService(IProductRepository repository, IChangeLogService logService)
+        private readonly IValidator<ProductDto> _validator;
+        private readonly IDbContextFactory<InvoiceContext> _contextFactory;
+
+        public ProductService(
+            IProductRepository repository,
+            IChangeLogService logService,
+            IValidator<ProductDto> validator,
+            IDbContextFactory<InvoiceContext> contextFactory)
             : base(repository, logService)
         {
+            _validator = validator;
+            _contextFactory = contextFactory;
         }
 
-        // GetAllAsync, GetByIdAsync, SaveAsync and DeleteAsync provided by BaseService
+        protected override async Task ValidateAsync(Product entity)
+        {
+            await _validator.ValidateAndThrowAsync(entity.ToDto());
 
-        // SaveAsync and DeleteAsync provided by BaseService
+            using var ctx = _contextFactory.CreateDbContext();
+
+            var nameExists = await ctx.Products
+                .AnyAsync(p => p.Id != entity.Id && p.Name.ToLower() == entity.Name.ToLower());
+            if (nameExists)
+            {
+                throw new BusinessRuleViolationException($"Product name '{entity.Name}' already exists.");
+            }
+
+            if (entity.Id != 0)
+            {
+                var hasHistory = await ctx.InvoiceItems.AnyAsync(i => i.ProductId == entity.Id);
+                if (hasHistory)
+                {
+                    var existing = await ctx.Products.AsNoTracking().FirstOrDefaultAsync(p => p.Id == entity.Id);
+                    if (existing != null && (
+                        existing.UnitId != entity.UnitId ||
+                        existing.TaxRateId != entity.TaxRateId ||
+                        !string.Equals(existing.Name, entity.Name, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        throw new BusinessRuleViolationException("Product cannot change Unit, TaxRate or Name once invoiced.");
+                    }
+                }
+            }
+        }
+
+        public override async Task DeleteAsync(int id)
+        {
+            using var ctx = _contextFactory.CreateDbContext();
+            var used = await ctx.InvoiceItems.AnyAsync(i => i.ProductId == id);
+            if (used)
+            {
+                throw new BusinessRuleViolationException("Product is referenced by invoice items and cannot be deleted.");
+            }
+
+            await base.DeleteAsync(id);
+        }
     }
 }

--- a/Services/TaxRateService.cs
+++ b/Services/TaxRateService.cs
@@ -3,17 +3,73 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using InvoiceApp.Models;
 using InvoiceApp.Repositories;
+using InvoiceApp.DTOs;
+using InvoiceApp.Mappers;
+using Microsoft.EntityFrameworkCore;
+using InvoiceApp.Data;
+using FluentValidation;
 using Serilog;
 
 namespace InvoiceApp.Services
 {
     public class TaxRateService : BaseService<TaxRate>, ITaxRateService
     {
-        public TaxRateService(ITaxRateRepository repository, IChangeLogService logService)
+        private readonly IValidator<TaxRateDto> _validator;
+        private readonly IDbContextFactory<InvoiceContext> _contextFactory;
+
+        public TaxRateService(
+            ITaxRateRepository repository,
+            IChangeLogService logService,
+            IValidator<TaxRateDto> validator,
+            IDbContextFactory<InvoiceContext> contextFactory)
             : base(repository, logService)
         {
+            _validator = validator;
+            _contextFactory = contextFactory;
         }
 
-        // CRUD methods provided by BaseService
+        protected override async Task ValidateAsync(TaxRate entity)
+        {
+            await _validator.ValidateAndThrowAsync(entity.ToDto());
+
+            if (entity.Percentage > 100m)
+            {
+                throw new BusinessRuleViolationException("Tax rate percentage cannot exceed 100.");
+            }
+
+            using var ctx = _contextFactory.CreateDbContext();
+
+            if (entity.Id != 0)
+            {
+                var used = await ctx.InvoiceItems.AnyAsync(i => i.TaxRateId == entity.Id) ||
+                           await ctx.Products.AnyAsync(p => p.TaxRateId == entity.Id);
+
+                if (used)
+                {
+                    var existing = await ctx.TaxRates.AsNoTracking().FirstOrDefaultAsync(t => t.Id == entity.Id);
+                    if (existing != null && (
+                        existing.Percentage != entity.Percentage ||
+                        existing.EffectiveFrom != entity.EffectiveFrom ||
+                        existing.EffectiveTo != entity.EffectiveTo ||
+                        !string.Equals(existing.Name, entity.Name, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        throw new BusinessRuleViolationException("Tax rate is immutable once used.");
+                    }
+                }
+            }
+        }
+
+        public override async Task DeleteAsync(int id)
+        {
+            using var ctx = _contextFactory.CreateDbContext();
+            var used = await ctx.InvoiceItems.AnyAsync(i => i.TaxRateId == id) ||
+                       await ctx.Products.AnyAsync(p => p.TaxRateId == id);
+            if (used)
+            {
+                throw new BusinessRuleViolationException("Tax rate is referenced and cannot be deleted.");
+            }
+
+            await base.DeleteAsync(id);
+        }
     }
 }

--- a/StartupOrchestrator.cs
+++ b/StartupOrchestrator.cs
@@ -65,6 +65,12 @@ namespace InvoiceApp
 
             services.AddSingleton<IValidator<InvoiceDto>, InvoiceDtoValidator>();
             services.AddSingleton<IValidator<PaymentMethodDto>, PaymentMethodDtoValidator>();
+            services.AddSingleton<IValidator<ProductDto>, ProductDtoValidator>();
+            services.AddSingleton<IValidator<ProductGroupDto>, ProductGroupDtoValidator>();
+            services.AddSingleton<IValidator<TaxRateDto>, TaxRateDtoValidator>();
+            services.AddSingleton<IValidator<InvoiceItemDto>, InvoiceItemDtoValidator>();
+            services.AddSingleton<IValidator<UnitDto>, UnitDtoValidator>();
+            services.AddSingleton<IValidator<SupplierDto>, SupplierDtoValidator>();
 
             services.AddSingleton<IChangeLogService, ChangeLogService>();
             services.AddSingleton<IInvoiceService, InvoiceService>();

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -488,33 +488,15 @@ namespace InvoiceApp.ViewModels
                 return;
             }
 
-            var latest = await _service.GetLatestForSupplierAsync(SelectedInvoice.SupplierId);
-            if (latest != null)
+            var next = await _service.GetNextNumberAsync(SelectedInvoice.SupplierId);
+            if (!string.IsNullOrEmpty(next))
             {
-                SelectedInvoice.Number = IncrementNumber(latest.Number);
+                SelectedInvoice.Number = next;
                 OnPropertyChanged(nameof(SelectedInvoice));
                 Log.Information("Suggested invoice number {Number}", SelectedInvoice.Number);
             }
         }
 
-        private static string IncrementNumber(string lastNumber)
-        {
-            if (string.IsNullOrWhiteSpace(lastNumber)) return "1";
-
-            var digits = new string(lastNumber.Reverse().TakeWhile(char.IsDigit).Reverse().ToArray());
-            if (digits.Length > 0 && int.TryParse(digits, out var n))
-            {
-                var prefix = lastNumber.Substring(0, lastNumber.Length - digits.Length);
-                return prefix + (n + 1).ToString($"D{digits.Length}");
-            }
-
-            if (int.TryParse(lastNumber, out var value))
-            {
-                return (value + 1).ToString();
-            }
-
-            return lastNumber;
-        }
 
         public async Task NewInvoice()
         {
@@ -529,9 +511,9 @@ namespace InvoiceApp.ViewModels
             {
                 invoice.Supplier = latest.Supplier;
                 invoice.SupplierId = latest.SupplierId;
-                invoice.Number = IncrementNumber(latest.Number);
                 invoice.PaymentMethod = latest.PaymentMethod;
                 invoice.PaymentMethodId = latest.PaymentMethodId;
+                invoice.Number = await _service.GetNextNumberAsync(invoice.SupplierId);
             }
             else
             {


### PR DESCRIPTION
## Summary
- implement validation logic for product, tax rate, product group and invoice item services
- add API for next invoice number and consume in UI
- register validators in StartupOrchestrator

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b630111a48322af286fe29c57458d