### PR TITLE
Implement VAT summary calculation

### DIFF
--- a/Models/VatSummary.cs
+++ b/Models/VatSummary.cs
@@ -1,0 +1,13 @@
+namespace InvoiceApp.Models
+{
+    /// <summary>
+    /// Represents VAT breakdown for a specific tax rate.
+    /// </summary>
+    public class VatSummary
+    {
+        public decimal Rate { get; init; }
+        public decimal Net { get; init; }
+        public decimal Vat { get; init; }
+        public decimal Gross => Net + Vat;
+    }
+}

--- a/Services/IInvoiceService.cs
+++ b/Services/IInvoiceService.cs
@@ -17,5 +17,6 @@ namespace InvoiceApp.Services
         Task DeleteAsync(int id);
         Task<string> GetNextNumberAsync(int supplierId);
         bool IsValid(Invoice invoice);
+        IEnumerable<VatSummary> CalculateVatSummary(Invoice invoice);
     }
 }

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -56,6 +56,19 @@ namespace InvoiceApp.Services
                     }
                 }
             }
+
+            var rate = await ctx.TaxRates.FirstOrDefaultAsync(r => r.Id == entity.TaxRateId);
+            var percent = rate?.Percentage ?? 0m;
+            if (entity.Net == 0m && entity.Gross != 0m)
+            {
+                entity.Net = percent == 0m
+                    ? entity.Gross
+                    : Math.Round(entity.Gross / (1 + percent / 100m), 2);
+            }
+            else
+            {
+                entity.Gross = Math.Round(entity.Net * (1 + percent / 100m), 2);
+            }
         }
 
         public override async Task DeleteAsync(int id)

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -311,6 +311,7 @@ namespace InvoiceApp.ViewModels
                 _itemService,
                 _productService,
                 _taxRateService,
+                _service,
                 _statusService,
                 () => ((RelayCommand)SaveCommand).RaiseCanExecuteChanged(),
                 MarkDirty,


### PR DESCRIPTION
## Summary
- add `VatSummary` model to describe net/VAT breakdown per rate
- expose `CalculateVatSummary` on `IInvoiceService` and implement it
- compute invoice amount from VAT summary
- compute product net/gross in `ProductService`
- update item totals view model to use `IInvoiceService`
- adjust test stubs to support VAT summary

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b72e5f1008322b87140d942f49c98