### PR TITLE
Fix db initialization flow

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -2,8 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:InvoiceApp"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             StartupUri="Views/MainWindow.xaml">
+            xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels">
     <Application.Resources>
         <viewModels:ViewModelLocator x:Key="ViewModelLocator" />
         <Style x:Key="RightAlignedCellStyle" TargetType="TextBlock">

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -10,20 +10,36 @@ namespace InvoiceApp
         protected override async void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
-            Services = await StartupOrchestrator.Configure();
-            if (StartupOrchestrator.IsNewDatabase)
-            {
-                var dlg = new Views.SampleDataDialog();
-                if (dlg.ShowDialog() == true)
-                {
-                    await StartupOrchestrator.PopulateSampleDataAsync(Services, dlg.Options);
-                }
-            }
+
             this.DispatcherUnhandledException += (s, args) =>
             {
                 MessageBox.Show($"Váratlan hiba: {args.Exception.Message}", "Hiba", MessageBoxButton.OK, MessageBoxImage.Error);
                 args.Handled = true;
             };
+
+            Services = await StartupOrchestrator.Configure();
+
+            if (!StartupOrchestrator.DatabaseFileExists(Services))
+            {
+                var dlg = new Views.SampleDataDialog();
+                if (dlg.ShowDialog() == true)
+                {
+                    await StartupOrchestrator.InitializeDatabaseAsync(Services);
+                    await StartupOrchestrator.PopulateSampleDataAsync(Services, dlg.Options);
+                }
+                else
+                {
+                    Shutdown();
+                    return;
+                }
+            }
+            else
+            {
+                await StartupOrchestrator.InitializeDatabaseAsync(Services);
+            }
+
+            var main = new Views.MainWindow();
+            main.Show();
         }
 
         protected override void OnExit(ExitEventArgs e)

--- a/StartupOrchestrator.cs
+++ b/StartupOrchestrator.cs
@@ -99,7 +99,6 @@ namespace InvoiceApp
                 .CreateLogger();
 
             var provider = services.BuildServiceProvider();
-            await InitializeDatabase(provider);
             return provider;
         }
 
@@ -215,7 +214,7 @@ namespace InvoiceApp
             conn.Close();
         }
 
-        private static async Task InitializeDatabase(IServiceProvider provider)
+        public static async Task InitializeDatabaseAsync(IServiceProvider provider)
         {
             using var scope = provider.CreateScope();
             var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<InvoiceContext>>();
@@ -246,6 +245,17 @@ namespace InvoiceApp
             RepairTables(ctx, dbPath);
 
             IsNewDatabase = isNew;
+        }
+
+        public static bool DatabaseFileExists(IServiceProvider provider)
+        {
+            using var scope = provider.CreateScope();
+            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<InvoiceContext>>();
+            using var ctx = factory.CreateDbContext();
+
+            var builder = new SqliteConnectionStringBuilder(ctx.Database.GetDbConnection().ConnectionString);
+            var dbPath = Path.GetFullPath(builder.DataSource);
+            return File.Exists(dbPath);
         }
 
         public static async Task PopulateSampleDataAsync(IServiceProvider provider, SampleDataOptions options)


### PR DESCRIPTION
## Summary
- prevent database creation until user confirms
- add helper to check if database file exists
- show main window manually after startup

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687bf50cf4748322ab0011697ad54844