### PR TITLE
Fix invoice totals use unsaved items

### DIFF
--- a/InvoiceApp.Tests/ItemsViewModelTests.cs
+++ b/InvoiceApp.Tests/ItemsViewModelTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.ObjectModel;
+using InvoiceApp.Models;
+using InvoiceApp.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace InvoiceApp.Tests
+{
+    [TestClass]
+    public class ItemsViewModelTests
+    {
+        private ItemsViewModel CreateVm(Invoice invoice)
+        {
+            return TestHelpers.CreateItemsViewModel(invoice);
+        }
+
+        [TestMethod]
+        public void TotalsUpdate_WhenAddingAndRemovingItems()
+        {
+            var invoice = new Invoice { IsGross = false };
+            var vm = CreateVm(invoice);
+
+            var item1 = new InvoiceItemViewModel(new InvoiceItem
+            {
+                Quantity = 2,
+                UnitPrice = 100m,
+                TaxRate = new TaxRate { Percentage = 27m }
+            }) { TaxRatePercentage = 27m };
+
+            var item2 = new InvoiceItemViewModel(new InvoiceItem
+            {
+                Quantity = 1,
+                UnitPrice = 50m,
+                TaxRate = new TaxRate { Percentage = 5m }
+            }) { TaxRatePercentage = 5m };
+
+            vm.Items = new ObservableCollection<InvoiceItemViewModel> { item1 };
+
+            Assert.AreEqual(200m, vm.TotalNet);
+            Assert.AreEqual(54m, vm.TotalVat);
+            Assert.AreEqual(254m, vm.TotalGross);
+
+            vm.Items.Add(item2);
+
+            Assert.AreEqual(250m, vm.TotalNet);
+            Assert.AreEqual(56.5m, vm.TotalVat);
+            Assert.AreEqual(306.5m, vm.TotalGross);
+
+            vm.Items.Remove(item1);
+
+            Assert.AreEqual(50m, vm.TotalNet);
+            Assert.AreEqual(2.5m, vm.TotalVat);
+            Assert.AreEqual(52.5m, vm.TotalGross);
+        }
+    }
+}

--- a/InvoiceApp.Tests/TestHelpers.cs
+++ b/InvoiceApp.Tests/TestHelpers.cs
@@ -81,5 +81,20 @@ namespace InvoiceApp.Tests
             return new InvoiceViewModel(stub, stub, stub, stub, stub, stub, stub,
                 new SupplierViewModel(stub), stub);
         }
+
+        public static ItemsViewModel CreateItemsViewModel(Invoice invoice)
+        {
+            var stub = new StubService<object>();
+            return new ItemsViewModel(
+                stub,
+                stub,
+                stub,
+                stub,
+                new StatusService(),
+                () => { },
+                () => { },
+                () => invoice.IsGross,
+                () => invoice);
+        }
     }
 }

--- a/ViewModels/ItemsViewModel.cs
+++ b/ViewModels/ItemsViewModel.cs
@@ -279,6 +279,8 @@ namespace InvoiceApp.ViewModels
             var invoice = CurrentInvoice;
             if (invoice == null) return;
 
+            // Use current Items when calculating totals
+            invoice.Items = Items.Select(vm => vm.Item).ToList();
             var breakdown = _invoiceService.CalculateVatSummary(invoice)
                 .Select(v => new VatBreakdownEntry
                 {


### PR DESCRIPTION
## Summary
- refresh invoice totals with current item list
- helper to create ItemsViewModel for tests
- test total calculations when adding/removing items

## Testing
- `dotnet test InvoiceApp.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c09d835088322b7a8e6cc0a959d1e