### PR TITLE
Improve startup loading and error handling

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows;
+using InvoiceApp.ViewModels;
 
 namespace InvoiceApp
 {
@@ -37,6 +38,16 @@ namespace InvoiceApp
             {
                 await StartupOrchestrator.InitializeDatabaseAsync(Services);
             }
+
+            var locator = new ViewModels.ViewModelLocator();
+            await locator.PaymentMethodViewModel.LoadAsync();
+            await locator.SupplierViewModel.LoadAsync();
+            await locator.UnitViewModel.LoadAsync();
+            await locator.ProductGroupViewModel.LoadAsync();
+            await locator.TaxRateViewModel.LoadAsync();
+            await locator.ProductViewModel.LoadAsync();
+            await locator.InvoiceViewModel.LoadAsync();
+            await locator.DashboardViewModel.LoadAsync();
 
             var main = new Views.MainWindow();
             main.Show();

--- a/Helpers/DialogHelper.cs
+++ b/Helpers/DialogHelper.cs
@@ -37,5 +37,10 @@ namespace InvoiceApp
         {
             MessageBox.Show(message, "Információ", MessageBoxButton.OK, MessageBoxImage.Information);
         }
+
+        public static void ShowError(string message)
+        {
+            MessageBox.Show(message, "Hiba", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 }

--- a/Helpers/InverseBooleanConverter.cs
+++ b/Helpers/InverseBooleanConverter.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace InvoiceApp.Helpers
+{
+    public class InverseBooleanConverter : IValueConverter
+    {
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value is bool b ? !b : value;
+
+        public object? ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => value is bool b ? !b : value;
+    }
+}

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using InvoiceApp.Services;
+using Serilog;
 
 namespace InvoiceApp.ViewModels
 {
@@ -46,12 +48,25 @@ namespace InvoiceApp.ViewModels
 
         public async Task LoadAsync()
         {
-            var invoices = await _invoiceService.GetAllAsync();
-            var products = await _productService.GetAllAsync();
-            var suppliers = await _supplierService.GetAllAsync();
-            InvoiceCount = invoices.Count();
-            ProductCount = products.Count();
-            SupplierCount = suppliers.Count();
+            try
+            {
+                IsLoading = true;
+                var invoices = await _invoiceService.GetAllAsync();
+                var products = await _productService.GetAllAsync();
+                var suppliers = await _supplierService.GetAllAsync();
+                InvoiceCount = invoices.Count();
+                ProductCount = products.Count();
+                SupplierCount = suppliers.Count();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load dashboard data");
+                DialogHelper.ShowError("Hiba történt a vezérlőpult betöltésekor.");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
         }
     }
 }

--- a/ViewModels/InvoiceViewModel.cs
+++ b/ViewModels/InvoiceViewModel.cs
@@ -355,32 +355,45 @@ namespace InvoiceApp.ViewModels
         public async Task LoadAsync()
         {
             Log.Debug("InvoiceViewModel.LoadAsync called");
-            ShowStatus("Betöltés...");
-            var items = await _service.GetHeadersAsync();
-            Invoices = new ObservableCollection<Invoice>(items);
-
-            var prods = await _productService.GetAllAsync();
-            Products = new ObservableCollection<Product>(prods);
-
-            var rates = await _taxRateService.GetAllAsync();
-            TaxRates = new ObservableCollection<TaxRate>(rates);
-
-            var sups = await _supplierService.GetAllAsync();
-            Suppliers = new ObservableCollection<Supplier>(sups);
-
-            var pays = await _paymentService.GetAllAsync();
-            PaymentMethods = new ObservableCollection<PaymentMethod>(pays);
-
-            var log = await _logService.GetLatestAsync();
-            if (log != null)
+            try
             {
-                ShowStatus($"Utolsó esemény: {log.Operation} ({log.DateCreated:g})");
+                IsLoading = true;
+                ShowStatus("Betöltés...");
+                var items = await _service.GetHeadersAsync();
+                Invoices = new ObservableCollection<Invoice>(items);
+
+                var prods = await _productService.GetAllAsync();
+                Products = new ObservableCollection<Product>(prods);
+
+                var rates = await _taxRateService.GetAllAsync();
+                TaxRates = new ObservableCollection<TaxRate>(rates);
+
+                var sups = await _supplierService.GetAllAsync();
+                Suppliers = new ObservableCollection<Supplier>(sups);
+
+                var pays = await _paymentService.GetAllAsync();
+                PaymentMethods = new ObservableCollection<PaymentMethod>(pays);
+
+                var log = await _logService.GetLatestAsync();
+                if (log != null)
+                {
+                    ShowStatus($"Utolsó esemény: {log.Operation} ({log.DateCreated:g})");
+                }
+                else
+                {
+                    ShowStatus(Invoices.Count == 0 ? "Üres lista." : $"{Invoices.Count} számla betöltve.");
+                }
+                ClearChanges();
             }
-            else
+            catch (Exception ex)
             {
-                ShowStatus(Invoices.Count == 0 ? "Üres lista." : $"{Invoices.Count} számla betöltve.");
+                Log.Error(ex, "Failed to load invoices");
+                DialogHelper.ShowError("Hiba történt a számlák betöltésekor.");
             }
-            ClearChanges();
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
         public InvoiceItemViewModel CreateItemViewModel()

--- a/ViewModels/PaymentMethodViewModel.cs
+++ b/ViewModels/PaymentMethodViewModel.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows;
 using InvoiceApp.Models;
 using InvoiceApp.Services;
 using InvoiceApp;
+using Serilog;
 
 namespace InvoiceApp.ViewModels
 {
@@ -40,8 +42,21 @@ namespace InvoiceApp.ViewModels
 
         public async Task LoadAsync()
         {
-            var items = await _service.GetAllAsync();
-            Methods = new ObservableCollection<PaymentMethod>(items);
+            try
+            {
+                IsLoading = true;
+                var items = await _service.GetAllAsync();
+                Methods = new ObservableCollection<PaymentMethod>(items);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load payment methods");
+                DialogHelper.ShowError("Hiba történt a fizetési módok betöltésekor.");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
         protected override PaymentMethod CreateNewItem() => new PaymentMethod();

--- a/ViewModels/ProductGroupViewModel.cs
+++ b/ViewModels/ProductGroupViewModel.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows;
 using InvoiceApp.Models;
 using InvoiceApp.Services;
 using InvoiceApp;
+using Serilog;
 
 namespace InvoiceApp.ViewModels
 {
@@ -40,8 +42,21 @@ namespace InvoiceApp.ViewModels
 
         public async Task LoadAsync()
         {
-            var items = await _service.GetAllAsync();
-            Groups = new ObservableCollection<ProductGroup>(items);
+            try
+            {
+                IsLoading = true;
+                var items = await _service.GetAllAsync();
+                Groups = new ObservableCollection<ProductGroup>(items);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load product groups");
+                DialogHelper.ShowError("Hiba történt a termékcsoportok betöltésekor.");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
         protected override ProductGroup CreateNewItem() => new ProductGroup();

--- a/ViewModels/SupplierViewModel.cs
+++ b/ViewModels/SupplierViewModel.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows;
 using InvoiceApp.Models;
 using InvoiceApp.Services;
 using InvoiceApp;
+using Serilog;
 
 namespace InvoiceApp.ViewModels
 {
@@ -50,8 +52,21 @@ namespace InvoiceApp.ViewModels
 
         public async Task LoadAsync()
         {
-            var items = await _service.GetAllAsync();
-            Suppliers = new ObservableCollection<Supplier>(items);
+            try
+            {
+                IsLoading = true;
+                var items = await _service.GetAllAsync();
+                Suppliers = new ObservableCollection<Supplier>(items);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load suppliers");
+                DialogHelper.ShowError("Hiba történt a szállítók betöltésekor.");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
         public Supplier AddSupplier()

--- a/ViewModels/TaxRateViewModel.cs
+++ b/ViewModels/TaxRateViewModel.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows;
 using InvoiceApp.Models;
 using InvoiceApp.Services;
 using InvoiceApp;
+using Serilog;
 
 namespace InvoiceApp.ViewModels
 {
@@ -40,8 +42,21 @@ namespace InvoiceApp.ViewModels
 
         public async Task LoadAsync()
         {
-            var items = await _service.GetAllAsync();
-            Rates = new ObservableCollection<TaxRate>(items);
+            try
+            {
+                IsLoading = true;
+                var items = await _service.GetAllAsync();
+                Rates = new ObservableCollection<TaxRate>(items);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load tax rates");
+                DialogHelper.ShowError("Hiba történt az áfakulcsok betöltésekor.");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
         protected override TaxRate CreateNewItem() => new TaxRate();

--- a/ViewModels/UnitViewModel.cs
+++ b/ViewModels/UnitViewModel.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows;
 using InvoiceApp.Models;
 using InvoiceApp.Services;
 using InvoiceApp;
+using Serilog;
 
 namespace InvoiceApp.ViewModels
 {
@@ -40,8 +42,21 @@ namespace InvoiceApp.ViewModels
 
         public async Task LoadAsync()
         {
-            var items = await _service.GetAllAsync();
-            Units = new ObservableCollection<Unit>(items);
+            try
+            {
+                IsLoading = true;
+                var items = await _service.GetAllAsync();
+                Units = new ObservableCollection<Unit>(items);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load units");
+                DialogHelper.ShowError("Hiba történt a mértékegységek betöltésekor.");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
         protected override Unit CreateNewItem() => new Unit();

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -7,6 +7,17 @@ namespace InvoiceApp.ViewModels
     {
         public event PropertyChangedEventHandler? PropertyChanged;
 
+        private bool _isLoading;
+        public bool IsLoading
+        {
+            get => _isLoading;
+            set
+            {
+                _isLoading = value;
+                OnPropertyChanged();
+            }
+        }
+
         protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/Views/DashboardView.xaml
+++ b/Views/DashboardView.xaml
@@ -3,6 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
              xmlns:helpers="clr-namespace:InvoiceApp.Helpers">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
+    </UserControl.Resources>
     <StackPanel Margin="20">
         <TextBlock Text="Vezérlőpult" FontSize="20" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,10"/>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
@@ -14,7 +18,8 @@
             <TextBlock Text="{Binding ProductCount}"/>
         </StackPanel>
         <ListView x:Name="MenuList" ItemsSource="{Binding MenuItems}" HorizontalAlignment="Center" Width="300"
-                  helpers:FocusBehavior.IsFocused="True">
+                  helpers:FocusBehavior.IsFocused="True"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}">
             <ListView.View>
                 <GridView>
                     <GridViewColumn Header="Funkció" DisplayMemberBinding="{Binding Key}" Width="70"/>
@@ -28,5 +33,9 @@
                 </GridView>
             </ListView.View>
         </ListView>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Padding="10" />
     </StackPanel>
 </UserControl>

--- a/Views/InvoiceListView.xaml
+++ b/Views/InvoiceListView.xaml
@@ -10,6 +10,7 @@
     </UserControl.InputBindings>
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -20,6 +21,7 @@
         <DataGrid x:Name="InvoicesGrid"
                   ItemsSource="{Binding Invoices}"
                   helpers:FocusBehavior.IsFocused="True"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"
                   SelectedItem="{Binding SelectedInvoice}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -33,6 +35,10 @@
                                       ElementStyle="{StaticResource RightAlignedCellStyle}" />
             </DataGrid.Columns>
         </DataGrid>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Grid.ColumnSpan="2" Padding="10" />
 
         <Grid Grid.Column="1">
             <Grid.RowDefinitions>

--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -7,6 +7,10 @@
             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
@@ -18,6 +22,7 @@
         <DataGrid x:Name="DataGrid"
                   ItemsSource="{Binding Methods}"
                   helpers:FocusBehavior.IsFocused="True"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"
                   SelectedItem="{Binding SelectedMethod}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -31,6 +36,10 @@
                                       ElementStyle="{StaticResource RightAlignedCellStyle}" />
             </DataGrid.Columns>
         </DataGrid>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Grid.RowSpan="2" Padding="10" />
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="Hozzáadás" Command="{Binding AddCommand}" Margin="4" />
             <Button Content="Törlés" Command="{Binding DeleteCommand}" Margin="4" />

--- a/Views/ProductGroupView.xaml
+++ b/Views/ProductGroupView.xaml
@@ -7,6 +7,10 @@
              xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
@@ -18,6 +22,7 @@
         <DataGrid x:Name="DataGrid"
                   ItemsSource="{Binding Groups}"
                   helpers:FocusBehavior.IsFocused="True"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"
                   SelectedItem="{Binding SelectedGroup}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -28,6 +33,10 @@
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Grid.RowSpan="2" Padding="10" />
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="Hozzáadás" Command="{Binding AddCommand}" Margin="4" />
             <Button Content="Törlés" Command="{Binding DeleteCommand}" Margin="4" />

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -7,6 +7,10 @@
              xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
@@ -44,6 +48,7 @@
         <DataGrid x:Name="DataGrid"
                   Grid.Row="1"
                   ItemsSource="{Binding ProductsView}"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"
                   SelectedItem="{Binding SelectedProduct}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -106,6 +111,10 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Grid.RowSpan="3" Padding="10" />
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="Hozzáadás" Command="{Binding AddCommand}" Margin="4" />
             <Button Content="Törlés" Command="{Binding DeleteCommand}" Margin="4" />

--- a/Views/SupplierView.xaml
+++ b/Views/SupplierView.xaml
@@ -7,6 +7,10 @@
              xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
@@ -18,6 +22,7 @@
         <DataGrid x:Name="DataGrid"
                   ItemsSource="{Binding Suppliers}"
                   helpers:FocusBehavior.IsFocused="True"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"
                   SelectedItem="{Binding SelectedSupplier}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -30,6 +35,10 @@
                 <DataGridTextColumn Header="Bankszámla" Binding="{Binding BankAccntNr, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Grid.RowSpan="2" Padding="10" />
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="Hozzáadás" Command="{Binding AddCommand}" Margin="4" />
             <Button Content="Törlés" Command="{Binding DeleteCommand}" Margin="4" />

--- a/Views/TaxRateView.xaml
+++ b/Views/TaxRateView.xaml
@@ -7,6 +7,10 @@
              xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
@@ -18,6 +22,7 @@
         <DataGrid x:Name="DataGrid"
                   ItemsSource="{Binding Rates}"
                   helpers:FocusBehavior.IsFocused="True"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"
                   SelectedItem="{Binding SelectedRate}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -34,6 +39,10 @@
                 <DataGridTextColumn Header="Vége" Binding="{Binding EffectiveTo, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Grid.RowSpan="2" Padding="10" />
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="Hozzáadás" Command="{Binding AddCommand}" Margin="4" />
             <Button Content="Törlés" Command="{Binding DeleteCommand}" Margin="4" />

--- a/Views/UnitView.xaml
+++ b/Views/UnitView.xaml
@@ -7,6 +7,10 @@
              xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:InverseBooleanConverter x:Key="InverseBoolConverter" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="Delete" Command="{Binding DeleteCommand}"/>
     </UserControl.InputBindings>
@@ -18,6 +22,7 @@
         <DataGrid x:Name="DataGrid"
                   ItemsSource="{Binding Units}"
                   helpers:FocusBehavior.IsFocused="True"
+                  IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"
                   SelectedItem="{Binding SelectedUnit}"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -29,6 +34,10 @@
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
             </DataGrid.Columns>
         </DataGrid>
+        <TextBlock Text="Betöltés..." FontWeight="Bold" FontSize="16" Background="White" Opacity="0.8"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibilityConverter}}"
+                   Grid.RowSpan="2" Padding="10" />
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="Hozzáadás" Command="{Binding AddCommand}" Margin="4" />
             <Button Content="Törlés" Command="{Binding DeleteCommand}" Margin="4" />


### PR DESCRIPTION
## Summary
- preload master data in `App.OnStartup`
- track loading state via `IsLoading` on `ViewModelBase`
- disable grids and show "Loading" message during load
- add error logging and dialogs in each `LoadAsync`
- introduce `InverseBooleanConverter` and new dialogs

## Testing
- `git diff HEAD~1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687c0d82e4508322b0a2752a78d36b93