### PR TITLE
Move inline styles to shared dictionary

### DIFF
--- a/Resources/Styles.xaml
+++ b/Resources/Styles.xaml
@@ -29,4 +29,48 @@
         <Setter Property="FontFamily" Value="{StaticResource AppFontFamily}" />
         <Setter Property="FontSize" Value="{StaticResource AppFontSize}" />
     </Style>
+
+    <!-- Highlighted border styles for MainWindow sections -->
+    <Style x:Key="HeaderBorderStyle" TargetType="Border">
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding CurrentState}" Value="Header">
+                <Setter Property="BorderBrush" Value="DodgerBlue" />
+                <Setter Property="BorderThickness" Value="2" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="ItemListBorderStyle" TargetType="Border">
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding CurrentState}" Value="ItemList">
+                <Setter Property="BorderBrush" Value="DodgerBlue" />
+                <Setter Property="BorderThickness" Value="2" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="SummaryBorderStyle" TargetType="Border">
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding CurrentState}" Value="Summary">
+                <Setter Property="BorderBrush" Value="DodgerBlue" />
+                <Setter Property="BorderThickness" Value="2" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- TextBlock hint shown in ProductView -->
+    <Style x:Key="GrossInputHintStyle" TargetType="TextBlock">
+        <Setter Property="Text" Value="Bruttó érték számított" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IsGrossInput}" Value="True">
+                <Setter Property="Text" Value="Bruttó érték szerkeszthető" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -60,19 +60,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <Border Grid.Row="0" Margin="0,0,0,4">
-                        <Border.Style>
-                            <Style TargetType="Border">
-                                <Setter Property="BorderThickness" Value="0"/>
-                                <Setter Property="BorderBrush" Value="Transparent"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding CurrentState}" Value="Header">
-                                        <Setter Property="BorderBrush" Value="DodgerBlue"/>
-                                        <Setter Property="BorderThickness" Value="2"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
+                    <Border Grid.Row="0" Margin="0,0,0,4" Style="{StaticResource HeaderBorderStyle}">
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                             <views:InvoiceHeaderView />
                             <Button Content="➕ Szállító"
@@ -82,19 +70,7 @@
                                     ToolTip="Szállító hozzáadása" />
                         </StackPanel>
                     </Border>
-                    <Border Grid.Row="1" Margin="0,0,0,4">
-                        <Border.Style>
-                            <Style TargetType="Border">
-                                <Setter Property="BorderThickness" Value="0"/>
-                                <Setter Property="BorderBrush" Value="Transparent"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding CurrentState}" Value="ItemList">
-                                        <Setter Property="BorderBrush" Value="DodgerBlue"/>
-                                        <Setter Property="BorderThickness" Value="2"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
+                    <Border Grid.Row="1" Margin="0,0,0,4" Style="{StaticResource ItemListBorderStyle}">
                         <views:InvoiceItemDataGrid x:Name="ItemsGrid" />
                     </Border>
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
@@ -115,19 +91,7 @@
                                 Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Mentés és új számla"/>
                     </StackPanel>
-                    <Border Grid.Row="3">
-                        <Border.Style>
-                            <Style TargetType="Border">
-                                <Setter Property="BorderThickness" Value="0"/>
-                                <Setter Property="BorderBrush" Value="Transparent"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding CurrentState}" Value="Summary">
-                                        <Setter Property="BorderBrush" Value="DodgerBlue"/>
-                                        <Setter Property="BorderThickness" Value="2"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
+                    <Border Grid.Row="3" Style="{StaticResource SummaryBorderStyle}">
                         <views:InvoiceSummaryPanel />
                     </Border>
                 </Grid>

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -32,18 +32,7 @@
             <CheckBox Content="Bruttó?" Margin="8,0,0,0"
                       IsChecked="{Binding IsGrossInput}"
                       ToolTip="Bejelölve a bruttó érték szerkeszthető, egyébként számított." />
-            <TextBlock Margin="8,0,0,0">
-                <TextBlock.Style>
-                    <Style TargetType="TextBlock">
-                        <Setter Property="Text" Value="Bruttó érték számított" />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsGrossInput}" Value="True">
-                                <Setter Property="Text" Value="Bruttó érték szerkeszthető" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </TextBlock.Style>
-            </TextBlock>
+            <TextBlock Margin="8,0,0,0" Style="{StaticResource GrossInputHintStyle}" />
         </StackPanel>
         <DataGrid x:Name="DataGrid"
                   Grid.Row="1"


### PR DESCRIPTION
## Summary
- centralize inline styles into `Resources/Styles.xaml`
- reference shared styles from `MainWindow.xaml` and `ProductView.xaml`

## Testing
- `xmllint --noout Resources/Styles.xaml`
- `xmllint --noout Views/ProductView.xaml`
- `xmllint --noout Views/MainWindow.xaml`


------
https://chatgpt.com/codex/tasks/task_e_687c1d4eb1ec832296e3b8b96dfb9297