### PR TITLE
Remove IconButtonStyle references

### DIFF
--- a/Views/InvoiceItemDataGrid.xaml
+++ b/Views/InvoiceItemDataGrid.xaml
@@ -79,7 +79,6 @@
                         <Button Content="💾 Mentés"
                                 Command="{Binding DataContext.SaveItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                 CommandParameter="{Binding}"
-                                Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Tétel mentése"/>
                     </DataTemplate>
                 </DataGridTemplateColumn.CellTemplate>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -35,7 +35,6 @@
                 <StackPanel Grid.Row="1" Grid.Column="0" Margin="4">
                     <Button Content="🆕 Új számla"
                             Command="{Binding InvoiceViewModel.NewInvoiceCommand}"
-                            Style="{StaticResource IconButtonStyle}"
                             Margin="0,0,0,4"
                             ToolTip="Új számla létrehozása"/>
                     <ListView x:Name="InvoicesList"
@@ -65,7 +64,6 @@
                             <views:InvoiceHeaderView />
                             <Button Content="➕ Szállító"
                                     Command="{Binding InvoiceViewModel.AddSupplierCommand}"
-                                    Style="{StaticResource IconButtonStyle}"
                                     Margin="8,0,0,0"
                                     ToolTip="Szállító hozzáadása" />
                         </StackPanel>
@@ -76,19 +74,15 @@
                     <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
                         <Button Content="➕ Tétel hozzáadása"
                                 Command="{Binding InvoiceViewModel.ItemsView.AddItemCommand}"
-                                Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Tétel hozzáadása"/>
                         <Button Content="🗑️ Tétel törlése"
                                 Command="{Binding InvoiceViewModel.ItemsView.RemoveItemCommand}"
-                                Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Tétel törlése"/>
                         <Button Content="💾 Mentés"
                                 Command="{Binding InvoiceViewModel.SaveCommand}"
-                                Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Számla mentése"/>
                         <Button Content="💾➕ Mentés és új"
                                 Command="{Binding InvoiceViewModel.SaveAndNewCommand}"
-                                Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Mentés és új számla"/>
                     </StackPanel>
                     <Border Grid.Row="3" Style="{StaticResource SummaryBorderStyle}">


### PR DESCRIPTION
## Summary
- delete unused IconButtonStyle references in MainWindow.xaml
- delete unused IconButtonStyle reference in InvoiceItemDataGrid.xaml

## Testing
- `xmllint --noout Views/MainWindow.xaml`
- `xmllint --noout Views/InvoiceItemDataGrid.xaml`
- ⚠️ `dotnet` was not found, so build/tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_687c21159dc48322ad36cf379e0311a7