### PR TITLE
Fix program exit due to duplicate MainWindow

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,8 +1,7 @@
 ﻿<Application x:Class="InvoiceApp.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             StartupUri="Views/MainWindow.xaml">
+            xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels">
     <Application.Resources>
         <ResourceDictionary>
             <viewModels:ViewModelLocator x:Key="ViewModelLocator" />

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -55,6 +55,7 @@ namespace InvoiceApp
             await locator.DashboardViewModel.LoadAsync();
 
             var main = new Views.MainWindow();
+            MainWindow = main;
             main.Show();
         }
 


### PR DESCRIPTION
## Summary
- remove `StartupUri` from `App.xaml`
- ensure the `App` class assigns `MainWindow`

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c262dc890832288ae40d684af42c1