### PR TITLE
Update TASKS.md with UI automation tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -52,6 +52,30 @@ This document outlines tasks to align the repository with the MVP requirements d
   depends_on: []
   constraints: []
   external: false
+- id: task-UI01-add-automation-names
+  goal: Add x:Name or AutomationProperties.Name to key XAML controls.
+  input: [Views]
+  output: [Views]
+  depends_on: []
+  constraints: []
+  external: false
+
+- id: task-UI02-ui-test-harness
+  goal: Create a small executable that opens specific dialogs for tests.
+  input: [Views, InvoiceApp.csproj]
+  output: [UITestHarness]
+  depends_on: []
+  constraints: []
+  external: false
+
+- id: task-UI03-appium-tests
+  goal: Implement Appium/WebDriver tests.
+  input: [UITestHarness, Views]
+  output: [AppiumTests]
+  depends_on: [task-UI02-ui-test-harness]
+  constraints: []
+  external: true
+
 ```
 
 These tasks can be taken up by temporary agents according to the modular system. Each agent must keep to the listed inputs and outputs and perform validation such as diff checks or syntax verification.


### PR DESCRIPTION
## Summary
- document tasks for adding UI automation names, a UI test harness, and Appium tests

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3e195a7c8322baa0dbae893a9b1f