### PR TITLE
Fix Appium test generics and project attributes

### DIFF
--- a/AppiumTests/AppiumTests.csproj
+++ b/AppiumTests/AppiumTests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="5.0.0" />

--- a/AppiumTests/UITests.cs
+++ b/AppiumTests/UITests.cs
@@ -15,7 +15,7 @@ namespace AppiumTests
     {
         private const string WinAppDriverUrl = "http://127.0.0.1:4723";
         private const string HarnessExe = "UITestHarness.exe";
-        private WindowsDriver? _session;
+        private WindowsDriver<WindowsElement>? _session;
         private Process? _process;
 
         [TestInitialize]
@@ -26,7 +26,7 @@ namespace AppiumTests
             var options = new AppiumOptions();
             options.AddAdditionalCapability("app", exePath);
             options.AddAdditionalCapability("deviceName", "WindowsPC");
-            _session = new WindowsDriver(new Uri(WinAppDriverUrl), options);
+            _session = new WindowsDriver<WindowsElement>(new Uri(WinAppDriverUrl), options);
         }
 
         [TestMethod]

--- a/InvoiceApp.Tests/InvoiceApp.Tests.csproj
+++ b/InvoiceApp.Tests/InvoiceApp.Tests.csproj
@@ -5,6 +5,7 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />

--- a/InvoiceApp.csproj
+++ b/InvoiceApp.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/UITestHarness/UITestHarness.csproj
+++ b/UITestHarness/UITestHarness.csproj
@@ -5,6 +5,7 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.csproj" />


### PR DESCRIPTION
## Summary
- use `WindowsDriver<WindowsElement>` in Appium test setup
- disable automatic TargetFramework attribute generation to avoid build duplication

## Testing
- `git diff --compact-summary`

------
https://chatgpt.com/codex/tasks/task_e_687c519ec6208322a4cea88457e350e2