### PR TITLE
Extract invoice handling into separate view

### DIFF
--- a/Helpers/AppStateTemplateSelector.cs
+++ b/Helpers/AppStateTemplateSelector.cs
@@ -10,7 +10,7 @@ namespace InvoiceApp.Helpers
     /// </summary>
     public class AppStateTemplateSelector : DataTemplateSelector
     {
-        public DataTemplate? MainWindowTemplate { get; set; }
+        public DataTemplate? InvoiceTemplate { get; set; }
         public DataTemplate? PaymentMethodsTemplate { get; set; }
         public DataTemplate? SuppliersTemplate { get; set; }
         public DataTemplate? ProductGroupsTemplate { get; set; }
@@ -18,9 +18,6 @@ namespace InvoiceApp.Helpers
         public DataTemplate? UnitsTemplate { get; set; }
         public DataTemplate? ProductsTemplate { get; set; }
         public DataTemplate? DashboardTemplate { get; set; }
-        public DataTemplate? HeaderTemplate { get; set; }
-        public DataTemplate? ItemListTemplate { get; set; }
-        public DataTemplate? SummaryTemplate { get; set; }
         public DataTemplate? ConfirmDialogTemplate { get; set; }
 
         public override DataTemplate? SelectTemplate(object item, DependencyObject container)
@@ -37,11 +34,12 @@ namespace InvoiceApp.Helpers
                 AppState.Units => UnitsTemplate,
                 AppState.Products => ProductsTemplate,
                 AppState.Dashboard => DashboardTemplate,
-                AppState.Header => MainWindowTemplate,
-                AppState.ItemList => MainWindowTemplate,
-                AppState.Summary => MainWindowTemplate,
+                AppState.Invoices => InvoiceTemplate,
+                AppState.Header => InvoiceTemplate,
+                AppState.ItemList => InvoiceTemplate,
+                AppState.Summary => InvoiceTemplate,
                 AppState.ConfirmDialog => ConfirmDialogTemplate,
-                _ => MainWindowTemplate
+                _ => InvoiceTemplate
             };
         }
     }

--- a/Models/AppState.cs
+++ b/Models/AppState.cs
@@ -17,6 +17,10 @@ namespace InvoiceApp.Models
         /// </summary>
         Dashboard,
         /// <summary>
+        /// Invoice management window.
+        /// </summary>
+        Invoices,
+        /// <summary>
         /// Invoice header information step.
         /// </summary>
         Header,
@@ -75,6 +79,7 @@ namespace InvoiceApp.Models
         {
             AppState.MainWindow => typeof(MainWindow),
             AppState.Dashboard => typeof(DashboardView),
+            AppState.Invoices => typeof(InvoiceWindow),
             AppState.Header => typeof(InvoiceHeaderView),
             AppState.ItemList => typeof(InvoiceItemDataGrid),
             AppState.Summary => typeof(InvoiceSummaryPanel),
@@ -98,6 +103,7 @@ namespace InvoiceApp.Models
         {
             AppState.MainWindow => "F\u0151ablak",
             AppState.Dashboard => "Vez\u00e9rl\u0151pult",
+            AppState.Invoices => "Sz\u00e1ml\u00e1k",
             AppState.Header => "Fejl\u00e9c",
             AppState.ItemList => "T\u00e9telek",
             AppState.Summary => "\u00d6sszes\u00edt\u0151",

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -22,7 +22,7 @@ namespace InvoiceApp.Services
 
         public NavigationService()
         {
-            _history.Push(AppState.MainWindow);
+            _history.Push(AppState.Invoices);
         }
 
         public void Push(AppState state)

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -37,7 +37,7 @@ namespace InvoiceApp.ViewModels
             MenuItems = new ObservableCollection<DashboardMenuItem>
             {
                 new DashboardMenuItem("F1", "Vezérlőpult", main.ShowDashboardCommand),
-                new DashboardMenuItem("F2", "Főablak", main.ShowMainWindowCommand),
+                new DashboardMenuItem("F2", "Számlák", main.ShowInvoicesCommand),
                 new DashboardMenuItem("F4", "Termékek", main.ShowProductsCommand),
                 new DashboardMenuItem("F5", "Termékcsoportok", main.ShowProductGroupsCommand),
                 new DashboardMenuItem("F6", "Szállítók", main.ShowSuppliersCommand),

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -75,6 +75,7 @@ namespace InvoiceApp.ViewModels
         public RelayCommand ShowTaxRatesCommand { get; }
         public RelayCommand ShowUnitsCommand { get; }
         public RelayCommand ShowProductsCommand { get; }
+        public RelayCommand ShowInvoicesCommand { get; }
         public RelayCommand ShowMainWindowCommand { get; }
         public RelayCommand ShowDashboardCommand { get; }
         public RelayCommand SwitchPaymentMethodsCommand { get; }
@@ -83,6 +84,7 @@ namespace InvoiceApp.ViewModels
         public RelayCommand SwitchTaxRatesCommand { get; }
         public RelayCommand SwitchUnitsCommand { get; }
         public RelayCommand SwitchProductsCommand { get; }
+        public RelayCommand SwitchInvoicesCommand { get; }
         public ICommand StateAddCommand { get; }
 
         public MainViewModel(INavigationService navigation,
@@ -170,6 +172,7 @@ namespace InvoiceApp.ViewModels
             ShowTaxRatesCommand = new RelayCommand(_ => _navigation.Push(AppState.TaxRates));
             ShowUnitsCommand = new RelayCommand(_ => _navigation.Push(AppState.Units));
             ShowProductsCommand = new RelayCommand(_ => _navigation.Push(AppState.Products));
+            ShowInvoicesCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Invoices));
             ShowMainWindowCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.MainWindow));
             ShowDashboardCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Dashboard));
             SwitchPaymentMethodsCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.PaymentMethods));
@@ -178,6 +181,7 @@ namespace InvoiceApp.ViewModels
             SwitchTaxRatesCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.TaxRates));
             SwitchUnitsCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Units));
             SwitchProductsCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Products));
+            SwitchInvoicesCommand = new RelayCommand(_ => _navigation.SwitchRoot(AppState.Invoices));
         }
 
         private void OnStateChanged(object? sender, AppState state)
@@ -202,6 +206,7 @@ namespace InvoiceApp.ViewModels
                     break;
                 case AppState.Dashboard:
                 case AppState.MainWindow:
+                case AppState.Invoices:
                     _statusService.Show(string.Empty);
                     break;
             }
@@ -231,6 +236,10 @@ namespace InvoiceApp.ViewModels
                 AppState.TaxRates => provider.GetRequiredService<TaxRateViewModel>(),
                 AppState.Units => provider.GetRequiredService<UnitViewModel>(),
                 AppState.Products => provider.GetRequiredService<ProductViewModel>(),
+                AppState.Invoices => InvoiceViewModel,
+                AppState.Header => InvoiceViewModel,
+                AppState.ItemList => InvoiceViewModel,
+                AppState.Summary => InvoiceViewModel,
                 _ => null
             };
         }

--- a/Views/InvoiceWindow.xaml
+++ b/Views/InvoiceWindow.xaml
@@ -1,0 +1,85 @@
+<UserControl x:Class="InvoiceApp.Views.InvoiceWindow"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:views="clr-namespace:InvoiceApp.Views"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             DataContext="{Binding Source={StaticResource ViewModelLocator}, Path=MainViewModel}">
+    <Grid helpers:FocusBehavior.IsFocused="{Binding InvoiceViewModel.IsInvoiceListFocused}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="220" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Menu Grid.Row="0" Grid.ColumnSpan="2">
+            <MenuItem Header="Ablakok">
+                <MenuItem Header="Fizetési módok" Command="{Binding ShowPaymentMethodsCommand}" />
+                <MenuItem Header="Szállítók" Command="{Binding ShowSuppliersCommand}" />
+                <MenuItem Header="Termékcsoportok" Command="{Binding ShowProductGroupsCommand}" />
+                <MenuItem Header="Áfakulcsok" Command="{Binding ShowTaxRatesCommand}" />
+                <MenuItem Header="Termékek" Command="{Binding ShowProductsCommand}" />
+                <MenuItem Header="Egységek" Command="{Binding ShowUnitsCommand}" />
+            </MenuItem>
+        </Menu>
+        <StackPanel Grid.Row="1" Grid.Column="0" Margin="4">
+            <Button x:Name="NewInvoiceButton" Content="🆕 Új számla"
+                    Command="{Binding InvoiceViewModel.NewInvoiceCommand}"
+                    Margin="0,0,0,4"
+                    ToolTip="Új számla létrehozása"/>
+            <ListView x:Name="InvoicesList"
+                      ItemsSource="{Binding InvoiceViewModel.Invoices}"
+                      SelectedItem="{Binding InvoiceViewModel.SelectedInvoice}"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding Number}" Margin="0,0,8,0"/>
+                            <TextBlock Text="{Binding Date, StringFormat='{}{0:d}'}" Margin="0,0,8,0"/>
+                            <TextBlock Text="{Binding Supplier.Name}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
+        <Grid Grid.Row="1" Grid.Column="1" Margin="4">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Border Grid.Row="0" Margin="0,0,0,4" Style="{StaticResource HeaderBorderStyle}">
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                    <views:InvoiceHeaderView />
+                    <Button x:Name="AddSupplierButton" Content="➕ Szállító"
+                            Command="{Binding InvoiceViewModel.AddSupplierCommand}"
+                            Margin="8,0,0,0"
+                            ToolTip="Szállító hozzáadása" />
+                </StackPanel>
+            </Border>
+            <Border Grid.Row="1" Margin="0,0,0,4" Style="{StaticResource ItemListBorderStyle}">
+                <views:InvoiceItemDataGrid x:Name="ItemsGrid" />
+            </Border>
+            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="AddItemButton" Content="➕ Tétel hozzáadása"
+                        Command="{Binding InvoiceViewModel.ItemsView.AddItemCommand}"
+                        ToolTip="Tétel hozzáadása"/>
+                <Button x:Name="RemoveItemButton" Content="🗑️ Tétel törlése"
+                        Command="{Binding InvoiceViewModel.ItemsView.RemoveItemCommand}"
+                        ToolTip="Tétel törlése"/>
+                <Button x:Name="SaveInvoiceButton" Content="💾 Mentés"
+                        Command="{Binding InvoiceViewModel.SaveCommand}"
+                        ToolTip="Számla mentése"/>
+                <Button x:Name="SaveAndNewInvoiceButton" Content="💾➕ Mentés és új"
+                        Command="{Binding InvoiceViewModel.SaveAndNewCommand}"
+                        ToolTip="Mentés és új számla"/>
+            </StackPanel>
+            <Border Grid.Row="3" Style="{StaticResource SummaryBorderStyle}">
+                <views:InvoiceSummaryPanel />
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Views/InvoiceWindow.xaml.cs
+++ b/Views/InvoiceWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace InvoiceApp.Views
+{
+    public partial class InvoiceWindow : UserControl
+    {
+        public InvoiceWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -11,85 +11,8 @@
         PreviewKeyDown="Window_PreviewKeyDown">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
-        <DataTemplate x:Key="MainWindowTemplate">
-            <Grid helpers:FocusBehavior.IsFocused="{Binding InvoiceViewModel.IsInvoiceListFocused}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="220" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Menu Grid.Row="0" Grid.ColumnSpan="2">
-                    <MenuItem Header="Ablakok">
-                        <MenuItem Header="Fizetési módok" Command="{Binding ShowPaymentMethodsCommand}" />
-                        <MenuItem Header="Szállítók" Command="{Binding ShowSuppliersCommand}" />
-                        <MenuItem Header="Termékcsoportok" Command="{Binding ShowProductGroupsCommand}" />
-                        <MenuItem Header="Áfakulcsok" Command="{Binding ShowTaxRatesCommand}" />
-                        <MenuItem Header="Termékek" Command="{Binding ShowProductsCommand}" />
-                        <MenuItem Header="Egységek" Command="{Binding ShowUnitsCommand}" />
-                    </MenuItem>
-                </Menu>
-                <StackPanel Grid.Row="1" Grid.Column="0" Margin="4">
-                    <Button x:Name="NewInvoiceButton" Content="🆕 Új számla"
-                            Command="{Binding InvoiceViewModel.NewInvoiceCommand}"
-                            Margin="0,0,0,4"
-                            ToolTip="Új számla létrehozása"/>
-                    <ListView x:Name="InvoicesList"
-                              ItemsSource="{Binding InvoiceViewModel.Invoices}"
-                              SelectedItem="{Binding InvoiceViewModel.SelectedInvoice}"
-                              ScrollViewer.VerticalScrollBarVisibility="Auto">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding Number}" Margin="0,0,8,0"/>
-                                    <TextBlock Text="{Binding Date, StringFormat='{}{0:d}'}" Margin="0,0,8,0"/>
-                                    <TextBlock Text="{Binding Supplier.Name}"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                </StackPanel>
-                <Grid Grid.Row="1" Grid.Column="1" Margin="4">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Border Grid.Row="0" Margin="0,0,0,4" Style="{StaticResource HeaderBorderStyle}">
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                            <views:InvoiceHeaderView />
-                            <Button x:Name="AddSupplierButton" Content="➕ Szállító"
-                                    Command="{Binding InvoiceViewModel.AddSupplierCommand}"
-                                    Margin="8,0,0,0"
-                                    ToolTip="Szállító hozzáadása" />
-                        </StackPanel>
-                    </Border>
-                    <Border Grid.Row="1" Margin="0,0,0,4" Style="{StaticResource ItemListBorderStyle}">
-                        <views:InvoiceItemDataGrid x:Name="ItemsGrid" />
-                    </Border>
-                    <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-                        <Button x:Name="AddItemButton" Content="➕ Tétel hozzáadása"
-                                Command="{Binding InvoiceViewModel.ItemsView.AddItemCommand}"
-                                ToolTip="Tétel hozzáadása"/>
-                        <Button x:Name="RemoveItemButton" Content="🗑️ Tétel törlése"
-                                Command="{Binding InvoiceViewModel.ItemsView.RemoveItemCommand}"
-                                ToolTip="Tétel törlése"/>
-                        <Button x:Name="SaveInvoiceButton" Content="💾 Mentés"
-                                Command="{Binding InvoiceViewModel.SaveCommand}"
-                                ToolTip="Számla mentése"/>
-                        <Button x:Name="SaveAndNewInvoiceButton" Content="💾➕ Mentés és új"
-                                Command="{Binding InvoiceViewModel.SaveAndNewCommand}"
-                                ToolTip="Mentés és új számla"/>
-                    </StackPanel>
-                    <Border Grid.Row="3" Style="{StaticResource SummaryBorderStyle}">
-                        <views:InvoiceSummaryPanel />
-                    </Border>
-                </Grid>
-            </Grid>
+        <DataTemplate x:Key="InvoiceTemplate">
+            <views:InvoiceWindow />
         </DataTemplate>
         <DataTemplate x:Key="PaymentMethodsTemplate">
             <views:PaymentMethodView />
@@ -112,20 +35,11 @@
         <DataTemplate x:Key="DashboardTemplate">
             <views:DashboardView />
         </DataTemplate>
-        <DataTemplate x:Key="HeaderTemplate">
-            <views:InvoiceHeaderView />
-        </DataTemplate>
-        <DataTemplate x:Key="ItemListTemplate">
-            <views:InvoiceItemDataGrid />
-        </DataTemplate>
-        <DataTemplate x:Key="SummaryTemplate">
-            <views:InvoiceSummaryPanel />
-        </DataTemplate>
         <DataTemplate x:Key="ConfirmDialogTemplate">
             <views:ConfirmDialog />
         </DataTemplate>
         <helpers:AppStateTemplateSelector x:Key="StateSelector"
-                                          MainWindowTemplate="{StaticResource MainWindowTemplate}"
+                                          InvoiceTemplate="{StaticResource InvoiceTemplate}"
                                           PaymentMethodsTemplate="{StaticResource PaymentMethodsTemplate}"
                                           SuppliersTemplate="{StaticResource SuppliersTemplate}"
                                           ProductGroupsTemplate="{StaticResource ProductGroupsTemplate}"
@@ -133,9 +47,6 @@
                                           UnitsTemplate="{StaticResource UnitsTemplate}"
                                           ProductsTemplate="{StaticResource ProductsTemplate}"
                                           DashboardTemplate="{StaticResource DashboardTemplate}"
-                                          HeaderTemplate="{StaticResource HeaderTemplate}"
-                                          ItemListTemplate="{StaticResource ItemListTemplate}"
-                                          SummaryTemplate="{StaticResource SummaryTemplate}"
                                           ConfirmDialogTemplate="{StaticResource ConfirmDialogTemplate}" />
     </Window.Resources>
     <Window.InputBindings>
@@ -146,7 +57,7 @@
         <KeyBinding Key="Insert" Command="{Binding StateAddCommand}"/>
         <KeyBinding Key="N" Modifiers="Control+Shift" Command="{Binding InvoiceViewModel.SaveAndNewCommand}"/>
         <KeyBinding Key="F1" Command="{Binding ShowDashboardCommand}"/>
-        <KeyBinding Key="F2" Command="{Binding ShowMainWindowCommand}"/>
+        <KeyBinding Key="F2" Command="{Binding ShowInvoicesCommand}"/>
         <KeyBinding Key="F4" Command="{Binding ShowProductsCommand}"/>
         <KeyBinding Key="F5" Command="{Binding ShowProductGroupsCommand}"/>
         <KeyBinding Key="F6" Command="{Binding ShowSuppliersCommand}"/>


### PR DESCRIPTION
## Summary
- add new `Invoices` app state and map it to a new `InvoiceWindow`
- simplify `MainWindow` resources and hotkeys
- update navigation service default state
- extend main and dashboard view models with invoice navigation commands

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5024b2348322ad176a6f5ffa0033