### PR TITLE
Fix duplicate TargetFramework attribute error

### DIFF
--- a/InvoiceApp.Tests/InvoiceApp.Tests.csproj
+++ b/InvoiceApp.Tests/InvoiceApp.Tests.csproj
@@ -5,7 +5,6 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />

--- a/InvoiceApp.csproj
+++ b/InvoiceApp.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/UITestHarness/UITestHarness.csproj
+++ b/UITestHarness/UITestHarness.csproj
@@ -5,7 +5,6 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.csproj" />


### PR DESCRIPTION
## Summary
- remove the `GenerateTargetFrameworkAttribute` suppression from projects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c583f02c08322902cd47e0f28511c