### PR TITLE
Fix build errors by suppressing TargetFramework attribute

### DIFF
--- a/FlaUITests/FlaUITests.csproj
+++ b/FlaUITests/FlaUITests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FlaUI.Core" Version="5.1.0" />

--- a/InvoiceApp.Tests/InvoiceApp.Tests.csproj
+++ b/InvoiceApp.Tests/InvoiceApp.Tests.csproj
@@ -5,6 +5,7 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />

--- a/InvoiceApp.csproj
+++ b/InvoiceApp.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/UITestHarness/UITestHarness.csproj
+++ b/UITestHarness/UITestHarness.csproj
@@ -5,6 +5,7 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.csproj" />


### PR DESCRIPTION
## Summary
- turn off TargetFramework attribute generation in every csproj to avoid duplicate assembly attributes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cbd67840483229a41a10f0692951a