### PR TITLE
Fix build errors by excluding test projects

### DIFF
--- a/InvoiceApp.csproj
+++ b/InvoiceApp.csproj
@@ -13,6 +13,14 @@
     <EmbeddedResource Remove="InvoiceApp.Tests\**" />
     <None Remove="InvoiceApp.Tests\**" />
     <Page Remove="InvoiceApp.Tests\**" />
+    <Compile Remove="FlaUITests\**" />
+    <EmbeddedResource Remove="FlaUITests\**" />
+    <None Remove="FlaUITests\**" />
+    <Page Remove="FlaUITests\**" />
+    <Compile Remove="UITestHarness\**" />
+    <EmbeddedResource Remove="UITestHarness\**" />
+    <None Remove="UITestHarness\**" />
+    <Page Remove="UITestHarness\**" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- prevent test and harness sources from compiling into the main executable

## Testing
- `dotnet restore InvoiceApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc56e4374832294b7259f6af4b369