### PR TITLE
Fix assembly attributes and namespace resolution

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 using System.Windows;
-using System.Runtime.Versioning;
-
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
                                                 //(used if a resource is not found in the page,
@@ -9,5 +7,3 @@ using System.Runtime.Versioning;
                                                 //(used if a resource is not found in the page,
                                                 // app, or any theme specific resource dictionaries)
 )]
-
-[assembly: SupportedOSPlatform("windows7.0")]

--- a/FlaUITests/FlaUITests.csproj
+++ b/FlaUITests/FlaUITests.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FlaUI.Core" Version="5.0.0" />

--- a/InvoiceApp.Tests/InvoiceApp.Tests.csproj
+++ b/InvoiceApp.Tests/InvoiceApp.Tests.csproj
@@ -5,7 +5,6 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />

--- a/InvoiceApp.csproj
+++ b/InvoiceApp.csproj
@@ -7,7 +7,6 @@
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UITestHarness/UITestHarness.csproj
+++ b/UITestHarness/UITestHarness.csproj
@@ -5,7 +5,6 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.csproj" />

--- a/Views/ConfirmDialog.xaml
+++ b/Views/ConfirmDialog.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="InvoiceApp.Views.ConfirmDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+        xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
         Title="Megerősítés"
         MinHeight="150" MinWidth="350"
         WindowStartupLocation="CenterOwner"

--- a/Views/DashboardView.xaml
+++ b/Views/DashboardView.xaml
@@ -1,8 +1,8 @@
 <UserControl x:Class="InvoiceApp.Views.DashboardView" DataContext="{Binding Source={StaticResource ViewModelLocator}, Path=DashboardViewModel}"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers">
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <helpers:InverseBooleanConverter x:Key="InverseBooleanConverter" />

--- a/Views/InvoiceHeaderView.xaml
+++ b/Views/InvoiceHeaderView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              d:DesignHeight="120" d:DesignWidth="400">
     <UserControl.InputBindings>

--- a/Views/InvoiceItemDataGrid.xaml
+++ b/Views/InvoiceItemDataGrid.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              d:DesignHeight="200" d:DesignWidth="400">
     <UserControl.Resources>

--- a/Views/InvoiceListView.xaml
+++ b/Views/InvoiceListView.xaml
@@ -1,9 +1,9 @@
 <UserControl x:Class="InvoiceApp.Views.InvoiceListView" DataContext="{Binding Source={StaticResource ViewModelLocator}, Path=InvoiceViewModel}"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
              xmlns:views="clr-namespace:InvoiceApp.Views"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              MinHeight="300" MinWidth="500">
     <UserControl.InputBindings>
         <KeyBinding Key="Delete" Command="{Binding DataContext.DeleteInvoiceCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>

--- a/Views/InvoiceWindow.xaml
+++ b/Views/InvoiceWindow.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:views="clr-namespace:InvoiceApp.Views"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              DataContext="{Binding Source={StaticResource ViewModelLocator}, Path=MainViewModel}">
     <Grid helpers:FocusBehavior.IsFocused="{Binding InvoiceViewModel.IsInvoiceListFocused}">
         <Grid.RowDefinitions>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -4,8 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:views="clr-namespace:InvoiceApp.Views"
-        xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-        xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+        xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+        xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
         mc:Ignorable="d"
         Title="Számlakezelő" MinHeight="600" MinWidth="1000"
         PreviewKeyDown="Window_PreviewKeyDown">

--- a/Views/PaymentMethodView.xaml
+++ b/Views/PaymentMethodView.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-            xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+            xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
     <UserControl.Resources>

--- a/Views/ProductGroupView.xaml
+++ b/Views/ProductGroupView.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
     <UserControl.Resources>

--- a/Views/ProductView.xaml
+++ b/Views/ProductView.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
     <UserControl.Resources>

--- a/Views/SupplierView.xaml
+++ b/Views/SupplierView.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
     <UserControl.Resources>

--- a/Views/TaxRateView.xaml
+++ b/Views/TaxRateView.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="500">
     <UserControl.Resources>

--- a/Views/UnitView.xaml
+++ b/Views/UnitView.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels"
-             xmlns:helpers="clr-namespace:InvoiceApp.Helpers"
+             xmlns:viewModels="clr-namespace:InvoiceApp.ViewModels;assembly=InvoiceApp"
+             xmlns:helpers="clr-namespace:InvoiceApp.Helpers;assembly=InvoiceApp"
              mc:Ignorable="d"
              MinHeight="300" MinWidth="400">
     <UserControl.Resources>


### PR DESCRIPTION
## Summary
- remove duplicate assembly attributes
- let MSBuild generate the TargetFramework attribute
- reference helpers and viewmodels with explicit assembly for XAML

## Testing
- `dotnet` command was unavailable in the container

------
https://chatgpt.com/codex/tasks/task_e_687cd283e81c83228cf3a321b64015dd