### PR TITLE
Fix duplicate TaxRate tracking

### DIFF
--- a/Repositories/EfInvoiceItemRepository.cs
+++ b/Repositories/EfInvoiceItemRepository.cs
@@ -69,7 +69,13 @@ namespace InvoiceApp.Repositories
             }
             if (item.TaxRate != null)
             {
-                ctx.Attach(item.TaxRate);
+                var existingRate = ctx.TaxRates.Local
+                    .FirstOrDefault(t => t.Id == item.TaxRate.Id);
+                item.TaxRate = existingRate ?? item.TaxRate;
+                if (existingRate == null)
+                {
+                    ctx.Attach(item.TaxRate);
+                }
             }
             await ctx.InvoiceItems.AddAsync(item);
             await ctx.SaveChangesAsync();
@@ -96,7 +102,13 @@ namespace InvoiceApp.Repositories
             }
             if (item.TaxRate != null)
             {
-                ctx.Attach(item.TaxRate);
+                var existingRate = ctx.TaxRates.Local
+                    .FirstOrDefault(t => t.Id == item.TaxRate.Id);
+                item.TaxRate = existingRate ?? item.TaxRate;
+                if (existingRate == null)
+                {
+                    ctx.Attach(item.TaxRate);
+                }
             }
             ctx.InvoiceItems.Update(item);
             await ctx.SaveChangesAsync();

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -245,8 +245,8 @@ namespace InvoiceApp.Services
                 await ctx.Products.AddRangeAsync(newProducts);
                 ctx.Products.UpdateRange(updateProducts);
 
-                await ctx.TaxRates.AddRangeAsync(newTaxRates);
-                ctx.TaxRates.UpdateRange(updateTaxRates);
+                await ctx.TaxRates.AddRangeAsync(newTaxRates.DistinctBy(t => t.Id));
+                ctx.TaxRates.UpdateRange(updateTaxRates.DistinctBy(t => t.Id));
 
                 await ctx.InvoiceItems.AddRangeAsync(newItems);
                 ctx.InvoiceItems.UpdateRange(updateItems);


### PR DESCRIPTION
## Summary
- deduplicate TaxRate entities when attaching InvoiceItems
- avoid adding/updating the same TaxRate twice in InvoiceService

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ced876e8883228412d20f47916d5d