### PR TITLE
Fix duplicate ProductGroup tracking

### DIFF
--- a/Repositories/EfInvoiceItemRepository.cs
+++ b/Repositories/EfInvoiceItemRepository.cs
@@ -65,6 +65,16 @@ namespace InvoiceApp.Repositories
                         ctx.Attach(item.Product.Unit);
                     }
                 }
+                if (item.Product.ProductGroup != null)
+                {
+                    var existingGroup = ctx.ProductGroups.Local
+                        .FirstOrDefault(g => g.Id == item.Product.ProductGroup.Id);
+                    item.Product.ProductGroup = existingGroup ?? item.Product.ProductGroup;
+                    if (existingGroup == null)
+                    {
+                        ctx.Attach(item.Product.ProductGroup);
+                    }
+                }
                 ctx.Attach(item.Product);
             }
             if (item.TaxRate != null)
@@ -96,6 +106,16 @@ namespace InvoiceApp.Repositories
                     if (existingUnit == null)
                     {
                         ctx.Attach(item.Product.Unit);
+                    }
+                }
+                if (item.Product.ProductGroup != null)
+                {
+                    var existingGroup = ctx.ProductGroups.Local
+                        .FirstOrDefault(g => g.Id == item.Product.ProductGroup.Id);
+                    item.Product.ProductGroup = existingGroup ?? item.Product.ProductGroup;
+                    if (existingGroup == null)
+                    {
+                        ctx.Attach(item.Product.ProductGroup);
                     }
                 }
                 ctx.Attach(item.Product);


### PR DESCRIPTION
## Summary
- avoid duplicate ProductGroup entities when saving invoice items

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf2e689448322b0cd2560467cb374