### PR TITLE
Enable lazy loading to reduce heavy Include chains

### DIFF
--- a/InvoiceApp.csproj
+++ b/InvoiceApp.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Bogus" Version="35.0.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />

--- a/Models/Invoice.cs
+++ b/Models/Invoice.cs
@@ -55,7 +55,7 @@ namespace InvoiceApp.Models
             set { if (_supplierId != value) { _supplierId = value; OnPropertyChanged(); } }
         }
 
-        public Supplier? Supplier
+        public virtual Supplier? Supplier
         {
             get => _supplier;
             set { if (_supplier != value) { _supplier = value; OnPropertyChanged(); } }
@@ -67,7 +67,7 @@ namespace InvoiceApp.Models
             set { if (_paymentMethodId != value) { _paymentMethodId = value; OnPropertyChanged(); } }
         }
 
-        public PaymentMethod? PaymentMethod
+        public virtual PaymentMethod? PaymentMethod
         {
             get => _paymentMethod;
             set { if (_paymentMethod != value) { _paymentMethod = value; OnPropertyChanged(); } }
@@ -79,7 +79,7 @@ namespace InvoiceApp.Models
             set { if (_isGross != value) { _isGross = value; OnPropertyChanged(); } }
         }
 
-        public List<InvoiceItem> Items { get; set; } = new();
+        public virtual List<InvoiceItem> Items { get; set; } = new();
 
         public event PropertyChangedEventHandler? PropertyChanged;
         public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;

--- a/Models/InvoiceItem.cs
+++ b/Models/InvoiceItem.cs
@@ -9,12 +9,12 @@ namespace InvoiceApp.Models
         public decimal UnitPrice { get; set; }
 
         public int InvoiceId { get; set; }
-        public Invoice? Invoice { get; set; }
+        public virtual Invoice? Invoice { get; set; }
 
         public int ProductId { get; set; }
-        public Product? Product { get; set; }
+        public virtual Product? Product { get; set; }
 
         public int TaxRateId { get; set; }
-        public TaxRate? TaxRate { get; set; }
+        public virtual TaxRate? TaxRate { get; set; }
     }
 }

--- a/Models/Product.cs
+++ b/Models/Product.cs
@@ -49,7 +49,7 @@ namespace InvoiceApp.Models
             set { if (_unitId != value) { _unitId = value; OnPropertyChanged(); } }
         }
 
-        public Unit? Unit
+        public virtual Unit? Unit
         {
             get => _unit;
             set { if (_unit != value) { _unit = value; OnPropertyChanged(); } }
@@ -61,7 +61,7 @@ namespace InvoiceApp.Models
             set { if (_productGroupId != value) { _productGroupId = value; OnPropertyChanged(); } }
         }
 
-        public ProductGroup? ProductGroup
+        public virtual ProductGroup? ProductGroup
         {
             get => _productGroup;
             set { if (_productGroup != value) { _productGroup = value; OnPropertyChanged(); } }
@@ -73,7 +73,7 @@ namespace InvoiceApp.Models
             set { if (_taxRateId != value) { _taxRateId = value; OnPropertyChanged(); } }
         }
 
-        public TaxRate? TaxRate
+        public virtual TaxRate? TaxRate
         {
             get => _taxRate;
             set { if (_taxRate != value) { _taxRate = value; OnPropertyChanged(); } }

--- a/Repositories/EfInvoiceItemRepository.cs
+++ b/Repositories/EfInvoiceItemRepository.cs
@@ -19,15 +19,7 @@ namespace InvoiceApp.Repositories
         {
             Log.Debug("EfInvoiceItemRepository.GetAllAsync called");
             using var ctx = ContextFactory.CreateDbContext();
-            var list = await ctx.InvoiceItems
-                .Include(i => i.Product!)
-                    .ThenInclude(p => p!.Unit)
-                .Include(i => i.Product!)
-                    .ThenInclude(p => p!.ProductGroup)
-                .Include(i => i.Product!)
-                    .ThenInclude(p => p!.TaxRate)
-                .Include(i => i.TaxRate)
-                .ToListAsync();
+            var list = await ctx.InvoiceItems.ToListAsync();
             Log.Debug("EfInvoiceItemRepository.GetAllAsync returning {Count} items", list.Count);
             return list;
         }
@@ -37,13 +29,6 @@ namespace InvoiceApp.Repositories
             Log.Debug("EfInvoiceItemRepository.GetByIdAsync called with {Id}", id);
             using var ctx = ContextFactory.CreateDbContext();
             var entity = await ctx.InvoiceItems
-                .Include(i => i.Product!)
-                    .ThenInclude(p => p!.Unit)
-                .Include(i => i.Product!)
-                    .ThenInclude(p => p!.ProductGroup)
-                .Include(i => i.Product!)
-                    .ThenInclude(p => p!.TaxRate)
-                .Include(i => i.TaxRate)
                 .FirstOrDefaultAsync(i => i.Id == id);
             Log.Debug(entity != null ? "EfInvoiceItemRepository.GetByIdAsync found {Id}" : "EfInvoiceItemRepository.GetByIdAsync no entity for {Id}", entity?.Id ?? id);
             return entity;

--- a/Repositories/EfInvoiceRepository.cs
+++ b/Repositories/EfInvoiceRepository.cs
@@ -29,17 +29,6 @@ namespace InvoiceApp.Repositories
             return await ctx.Invoices
                 .Include(i => i.Supplier)
                 .Include(i => i.PaymentMethod)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.Product)
-                        .ThenInclude(p => p.Unit)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.Product)
-                        .ThenInclude(p => p.ProductGroup)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.Product)
-                        .ThenInclude(p => p.TaxRate)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.TaxRate)
                 .FirstOrDefaultAsync(i => i.Id == id);
         }
 
@@ -51,17 +40,6 @@ namespace InvoiceApp.Repositories
                 var invoices = await ctx.Invoices
                     .Include(i => i.Supplier)
                     .Include(i => i.PaymentMethod)
-                    .Include(i => i.Items)
-                        .ThenInclude(it => it.Product)
-                            .ThenInclude(p => p.Unit)
-                    .Include(i => i.Items)
-                        .ThenInclude(it => it.Product)
-                            .ThenInclude(p => p.ProductGroup)
-                    .Include(i => i.Items)
-                        .ThenInclude(it => it.Product)
-                            .ThenInclude(p => p.TaxRate)
-                    .Include(i => i.Items)
-                        .ThenInclude(it => it.TaxRate)
                     .ToListAsync();
 
                 Serilog.Log.Debug("Loaded {Count} invoices with navigation properties", invoices.Count);
@@ -80,25 +58,11 @@ namespace InvoiceApp.Repositories
             var invoice = await ctx.Invoices
                 .Include(i => i.Supplier)
                 .Include(i => i.PaymentMethod)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.Product)
-                        .ThenInclude(p => p.Unit)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.Product)
-                        .ThenInclude(p => p.ProductGroup)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.Product)
-                        .ThenInclude(p => p.TaxRate)
-                .Include(i => i.Items)
-                    .ThenInclude(it => it.TaxRate)
                 .FirstOrDefaultAsync(i => i.Id == id);
 
             if (invoice != null)
             {
-                Serilog.Log.Debug(
-                    "Loaded invoice {Id} with {Items} items and navigation properties",
-                    invoice.Id,
-                    invoice.Items?.Count ?? 0);
+                Serilog.Log.Debug("Loaded invoice {Id}", invoice.Id);
             }
             else
             {

--- a/Repositories/EfProductRepository.cs
+++ b/Repositories/EfProductRepository.cs
@@ -18,11 +18,7 @@ namespace InvoiceApp.Repositories
         {
             Log.Debug("EfProductRepository.GetAllAsync called");
             using var ctx = ContextFactory.CreateDbContext();
-            var list = await ctx.Products
-                .Include(p => p.Unit)
-                .Include(p => p.ProductGroup)
-                .Include(p => p.TaxRate)
-                .ToListAsync();
+            var list = await ctx.Products.ToListAsync();
             Log.Debug("EfProductRepository.GetAllAsync returning {Count} items", list.Count);
             return list;
         }
@@ -32,9 +28,6 @@ namespace InvoiceApp.Repositories
             Log.Debug("EfProductRepository.GetByIdAsync called with {Id}", id);
             using var ctx = ContextFactory.CreateDbContext();
             var entity = await ctx.Products
-                .Include(p => p.Unit)
-                .Include(p => p.ProductGroup)
-                .Include(p => p.TaxRate)
                 .FirstOrDefaultAsync(p => p.Id == id);
             Log.Debug(entity != null ? "EfProductRepository.GetByIdAsync found {Id}" : "EfProductRepository.GetByIdAsync no entity for {Id}", entity?.Id ?? id);
             return entity;

--- a/StartupOrchestrator.cs
+++ b/StartupOrchestrator.cs
@@ -52,7 +52,9 @@ namespace InvoiceApp
             var connection = config["ConnectionString"] ?? $"Data Source={Path.Combine(AppContext.BaseDirectory, "invoice.db")}";
 
             var services = new ServiceCollection();
-            services.AddDbContextFactory<InvoiceContext>(o => o.UseSqlite(connection));
+            services.AddDbContextFactory<InvoiceContext>(o =>
+                o.UseLazyLoadingProxies()
+                 .UseSqlite(connection));
             services.AddSingleton<IInvoiceRepository, EfInvoiceRepository>();
             services.AddSingleton<IChangeLogRepository, EfChangeLogRepository>();
             services.AddSingleton<IInvoiceItemRepository, EfInvoiceItemRepository>();


### PR DESCRIPTION
## Summary
- add EF Core Proxies package for lazy loading
- enable lazy loading proxies in `StartupOrchestrator`
- mark navigation properties as `virtual`
- simplify repository queries to rely on lazy loading instead of deep Include chains

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_687d54643ed08322abdc6509733fddb7