### PR TITLE
Fix duplicate compile items

### DIFF
--- a/InvoiceApp.csproj
+++ b/InvoiceApp.csproj
@@ -38,10 +38,6 @@
     <Resource Include="Resources\Fonts\IBMPlexMono-*.ttf" />
   </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings.resx" />
-    <Compile Include="Resources\Strings.Designer.cs" />
-  </ItemGroup>
 
 </Project>
 


### PR DESCRIPTION
## Summary
- remove explicit entries for Strings resource files from project file
- tidy up empty `ItemGroup`

## Testing
- `python3 - <<'EOF'
import xml.etree.ElementTree as ET
ET.parse('InvoiceApp.csproj')
print("xml valid")
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687d61433afc8322ac782a5d38527808