### PR TITLE
Add F9 shortcut for Units view

### DIFF
--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -153,6 +153,7 @@
         <KeyBinding Key="F6" Command="{Binding ShowSuppliersCommand}"/>
         <KeyBinding Key="F7" Command="{Binding ShowTaxRatesCommand}"/>
         <KeyBinding Key="F8" Command="{Binding ShowPaymentMethodsCommand}"/>
+        <KeyBinding Key="F9" Command="{Binding ShowUnitsCommand}"/>
     </Window.InputBindings>
     <DockPanel>
         <TextBlock DockPanel.Dock="Top"


### PR DESCRIPTION
## Summary
- enable Units view from main window via `F9` key

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d65ca87d88322b40d397742ccd202