### PR TITLE
Fix FocusBehavior namespace in ConfirmDialog

### DIFF
--- a/Presentation/Views/ConfirmDialog.xaml
+++ b/Presentation/Views/ConfirmDialog.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="InvoiceApp.Presentation.Views.ConfirmDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:helpers="clr-namespace:InvoiceApp.Shared.Helpers;assembly=InvoiceApp"
+        xmlns:helpers="clr-namespace:InvoiceApp.Shared.Helpers"
         Title="Megerősítés"
         MinHeight="150" MinWidth="350"
         WindowStartupLocation="CenterOwner"


### PR DESCRIPTION
## Summary
- fix namespace for `FocusBehavior` in ConfirmDialog.xaml

## Testing
- `xmllint Presentation/Views/ConfirmDialog.xaml`

------
https://chatgpt.com/codex/tasks/task_e_687d858d72c8832297ddf50a95d3349b