### PR TITLE
Make EF navigation properties virtual

### DIFF
--- a/Domain/Invoice.cs
+++ b/Domain/Invoice.cs
@@ -11,13 +11,13 @@ namespace InvoiceApp.Domain
         public decimal Amount { get; set; }
 
         public int SupplierId { get; set; }
-        public Supplier? Supplier { get; set; }
+        public virtual Supplier? Supplier { get; set; }
 
         public int PaymentMethodId { get; set; }
-        public PaymentMethod? PaymentMethod { get; set; }
+        public virtual PaymentMethod? PaymentMethod { get; set; }
 
         public bool IsGross { get; set; } = true;
 
-        public List<InvoiceItem> Items { get; set; } = new();
+        public virtual List<InvoiceItem> Items { get; set; } = new();
     }
 }

--- a/Domain/Product.cs
+++ b/Domain/Product.cs
@@ -9,12 +9,12 @@ namespace InvoiceApp.Domain
         public decimal Gross { get; set; }
 
         public int UnitId { get; set; }
-        public Unit? Unit { get; set; }
+        public virtual Unit? Unit { get; set; }
 
         public int ProductGroupId { get; set; }
-        public ProductGroup? ProductGroup { get; set; }
+        public virtual ProductGroup? ProductGroup { get; set; }
 
         public int TaxRateId { get; set; }
-        public TaxRate? TaxRate { get; set; }
+        public virtual TaxRate? TaxRate { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- fix EF runtime error when using `UseLazyLoadingProxies`
- make navigation properties `virtual` so EF can generate proxies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d86e817f0832291523cfb6b53aec0