### PR TITLE
Fix converter usage in grid and product view

### DIFF
--- a/Presentation/ViewModels/InvoiceViewModel.cs
+++ b/Presentation/ViewModels/InvoiceViewModel.cs
@@ -607,12 +607,6 @@ namespace InvoiceApp.Presentation.ViewModels
             ClearChanges();
         }
 
-        private void Items_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            ItemsView.Items.CollectionChanged -= Items_CollectionChanged;
-            ItemsView.Items.CollectionChanged += Items_CollectionChanged;
-        }
-
         private void Item_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             ItemsView.UpdateGrossMode(Header.IsGrossCalculation);

--- a/Presentation/Views/InvoiceItemDataGrid.xaml
+++ b/Presentation/Views/InvoiceItemDataGrid.xaml
@@ -8,13 +8,14 @@
              d:DesignHeight="200" d:DesignWidth="400">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <helpers:BoolToRowDetailsVisibilityConverter x:Key="BoolToRowDetailsVisibilityConverter" />
     </UserControl.Resources>
     <DataGrid x:Name="InnerGrid"
               ItemsSource="{Binding Items}"
               SelectedItem="{Binding SelectedItem}"
               AutoGenerateColumns="False"
              CanUserAddRows="True"
-              RowDetailsVisibilityMode="{Binding IsRowDetailsVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+              RowDetailsVisibilityMode="{Binding IsRowDetailsVisible, Converter={StaticResource BoolToRowDetailsVisibilityConverter}}"
               PreviewKeyDown="DataGrid_PreviewKeyDown"
               InitializingNewItem="DataGrid_InitializingNewItem"
               LoadingRow="DataGrid_LoadingRow"

--- a/Presentation/Views/ProductView.xaml
+++ b/Presentation/Views/ProductView.xaml
@@ -26,9 +26,9 @@
                      Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                      helpers:FocusBehavior.IsFocused="True" />
             <Button x:Name="ShowProductGroupsButton" Content="Csoportok" Margin="8,0,0,0"
-                    Command="{Binding DataContext.ShowProductGroupsCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                    Command="{Binding DataContext.ShowProductGroupsCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
             <Button x:Name="ShowUnitsButton" Content="Egységek" Margin="4,0,0,0"
-                    Command="{Binding DataContext.ShowUnitsCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                    Command="{Binding DataContext.ShowUnitsCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
             <CheckBox Content="Bruttó?" Margin="8,0,0,0"
                       IsChecked="{Binding IsGrossInput}"
                       ToolTip="Bejelölve a bruttó érték szerkeszthető, egyébként számított." />
@@ -62,7 +62,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                     <DataGridTemplateColumn.CellEditingTemplate>
                         <DataTemplate>
-                            <ComboBox ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=Window}}"
+                            <ComboBox ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                       SelectedItem="{Binding TaxRate, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}"
                                       DisplayMemberPath="Percentage"
                                       IsEditable="True"
@@ -78,7 +78,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                     <DataGridTemplateColumn.CellEditingTemplate>
                         <DataTemplate>
-                            <ComboBox ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=Window}}"
+                            <ComboBox ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                       SelectedItem="{Binding Unit, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}"
                                       DisplayMemberPath="Code" />
                         </DataTemplate>
@@ -92,7 +92,7 @@
                     </DataGridTemplateColumn.CellTemplate>
                     <DataGridTemplateColumn.CellEditingTemplate>
                         <DataTemplate>
-                            <ComboBox ItemsSource="{Binding DataContext.Groups, RelativeSource={RelativeSource AncestorType=Window}}"
+                            <ComboBox ItemsSource="{Binding DataContext.Groups, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                       SelectedItem="{Binding ProductGroup, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}"
                                       DisplayMemberPath="Name" />
                         </DataTemplate>

--- a/Shared/Helpers/BoolToRowDetailsVisibilityConverter.cs
+++ b/Shared/Helpers/BoolToRowDetailsVisibilityConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace InvoiceApp.Shared.Helpers
+{
+    public class BoolToRowDetailsVisibilityConverter : IValueConverter
+    {
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is bool b && b
+                ? DataGridRowDetailsVisibilityMode.Visible
+                : DataGridRowDetailsVisibilityMode.Collapsed;
+        }
+
+        public object? ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is DataGridRowDetailsVisibilityMode mode && mode == DataGridRowDetailsVisibilityMode.Visible;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add BoolToRowDetailsVisibilityConverter
- fix invoice item grid details visibility binding
- correct ancestor bindings in product view comboboxes
- remove unused collection changed handler

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test --no-build` *(fails: same reason)*

------
https://chatgpt.com/codex/tasks/task_e_687d8ed8415c83228184124ce31ee15f