### PR TITLE
Centralize tax rate logic

### DIFF
--- a/Application/Services/ITaxRateService.cs
+++ b/Application/Services/ITaxRateService.cs
@@ -10,5 +10,10 @@ namespace InvoiceApp.Application.Services
         Task<TaxRate?> GetByIdAsync(int id);
         Task SaveAsync(TaxRate rate);
         Task DeleteAsync(int id);
+        /// <summary>
+        /// Returns an existing tax rate matching the percentage or creates a new one.
+        /// </summary>
+        /// <param name="percentage">Percentage value of the tax rate.</param>
+        Task<TaxRate> EnsureTaxRateExistsAsync(decimal percentage);
     }
 }

--- a/Application/Services/TaxRateService.cs
+++ b/Application/Services/TaxRateService.cs
@@ -28,6 +28,27 @@ namespace InvoiceApp.Application.Services
             _contextFactory = contextFactory;
         }
 
+        public async Task<TaxRate> EnsureTaxRateExistsAsync(decimal percentage)
+        {
+            foreach (var rate in await Repository.GetAllAsync())
+            {
+                if (Math.Abs(rate.Percentage - percentage) < 0.0001m)
+                    return rate;
+            }
+
+            var newRate = new TaxRate
+            {
+                Name = $"ÁFA {percentage}%",
+                Percentage = percentage,
+                EffectiveFrom = DateTime.Today,
+                Active = true,
+                DateCreated = DateTime.Now,
+                DateUpdated = DateTime.Now
+            };
+            await SaveAsync(newRate);
+            return newRate;
+        }
+
         protected override async Task ValidateAsync(TaxRate entity)
         {
             await _validator.ValidateAndThrowAsync(entity.ToDto());

--- a/Presentation/ViewModels/InvoiceViewModel.cs
+++ b/Presentation/ViewModels/InvoiceViewModel.cs
@@ -459,17 +459,9 @@ namespace InvoiceApp.Presentation.ViewModels
                 }
                 else
                 {
-                    rate = new TaxRate
-                    {
-                        Name = $"ÁFA {item.TaxRatePercentage}%",
-                        Percentage = item.TaxRatePercentage,
-                        EffectiveFrom = DateTime.Today,
-                        Active = true,
-                        DateCreated = DateTime.Now,
-                        DateUpdated = DateTime.Now
-                    };
-                    await _taxRateService.SaveAsync(rate);
-                    TaxRates.Add(rate);
+                    rate = await _taxRateService.EnsureTaxRateExistsAsync(item.TaxRatePercentage);
+                    if (!TaxRates.Any(r => r.Id == rate.Id))
+                        TaxRates.Add(rate);
                 }
             }
 


### PR DESCRIPTION
## Summary
- centralize tax rate creation in `TaxRateService`
- update `ProductViewModel` and `InvoiceViewModel` to use new service
- reuse `AmountCalculator` for product price calculations

## Testing
- `dotnet` not available so build/tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_687da1eb35e0832289782dd9d3c82186