### PR TITLE
Enhance UI with locked products and required invoice fields

### DIFF
--- a/Application/DTOs/ProductDto.cs
+++ b/Application/DTOs/ProductDto.cs
@@ -11,5 +11,10 @@ namespace InvoiceApp.Application.DTOs
         public int UnitId { get; set; }
         public int ProductGroupId { get; set; }
         public int TaxRateId { get; set; }
+
+        /// <summary>
+        /// True when the product is referenced by invoices.
+        /// </summary>
+        public bool IsLocked { get; set; }
     }
 }

--- a/Application/Mappers/EntityToDtoMapper.cs
+++ b/Application/Mappers/EntityToDtoMapper.cs
@@ -180,7 +180,8 @@ namespace InvoiceApp.Application.Mappers
                 Gross = entity.Gross,
                 UnitId = entity.UnitId,
                 ProductGroupId = entity.ProductGroupId,
-                TaxRateId = entity.TaxRateId
+                TaxRateId = entity.TaxRateId,
+                IsLocked = entity.IsLocked
             };
         }
 
@@ -196,7 +197,8 @@ namespace InvoiceApp.Application.Mappers
                 Gross = dto.Gross,
                 UnitId = dto.UnitId,
                 ProductGroupId = dto.ProductGroupId,
-                TaxRateId = dto.TaxRateId
+                TaxRateId = dto.TaxRateId,
+                IsLocked = dto.IsLocked
             };
         }
 

--- a/Application/Services/ProductService.cs
+++ b/Application/Services/ProductService.cs
@@ -28,6 +28,21 @@ namespace InvoiceApp.Application.Services
             _contextFactory = contextFactory;
         }
 
+        public override async Task<IEnumerable<Product>> GetAllAsync()
+        {
+            var products = await base.GetAllAsync();
+            using var ctx = _contextFactory.CreateDbContext();
+            var lockedIds = await ctx.InvoiceItems
+                .Select(i => i.ProductId)
+                .Distinct()
+                .ToListAsync();
+            foreach (var product in products)
+            {
+                product.IsLocked = lockedIds.Contains(product.Id);
+            }
+            return products;
+        }
+
         protected override async Task ValidateAsync(Product entity)
         {
             await _validator.ValidateAndThrowAsync(entity.ToDto());

--- a/Domain/Product.cs
+++ b/Domain/Product.cs
@@ -16,5 +16,12 @@ namespace InvoiceApp.Domain
 
         public int TaxRateId { get; set; }
         public virtual TaxRate? TaxRate { get; set; }
+
+        /// <summary>
+        /// Indicates whether the product is referenced by any invoice items
+        /// and therefore cannot be modified or deleted.
+        /// </summary>
+        [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+        public bool IsLocked { get; set; }
     }
 }

--- a/Presentation/ViewModels/ProductViewModel.cs
+++ b/Presentation/ViewModels/ProductViewModel.cs
@@ -97,6 +97,7 @@ namespace InvoiceApp.Presentation.ViewModels
             {
                 SelectedItem = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(SelectedProductLocked));
 
                 if (SelectedItem != null)
                 {
@@ -104,6 +105,11 @@ namespace InvoiceApp.Presentation.ViewModels
                 }
             }
         }
+
+        /// <summary>
+        /// True when the currently selected product cannot be edited.
+        /// </summary>
+        public bool SelectedProductLocked => SelectedProduct?.IsLocked ?? false;
 
 
         public ProductViewModel(IProductService service,

--- a/Presentation/Views/InvoiceHeaderView.xaml
+++ b/Presentation/Views/InvoiceHeaderView.xaml
@@ -6,6 +6,14 @@
              xmlns:helpers="clr-namespace:InvoiceApp.Shared.Helpers"
              mc:Ignorable="d"
              d:DesignHeight="120" d:DesignWidth="400">
+    <UserControl.Resources>
+        <ControlTemplate x:Key="RequiredTemplate">
+            <DockPanel>
+                <AdornedElementPlaceholder />
+                <TextBlock Foreground="Red" Text="*" Margin="2,0,0,0"/>
+            </DockPanel>
+        </ControlTemplate>
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding HeaderEscapeCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
         <KeyBinding Key="Up" Command="{Binding HeaderUpCommand, RelativeSource={RelativeSource AncestorType=Window}}"/>
@@ -33,6 +41,8 @@
                   IsEditable="True"
                   IsTextSearchEnabled="True"
                   LostFocus="SupplierBox_LostFocus"
+                  Validation.ErrorTemplate="{StaticResource RequiredTemplate}"
+                  ToolTip="Kötelező mező"
                   helpers:FocusBehavior.IsFocused="True"
                   helpers:FocusBehavior.AdvanceOnEnter="True"/>
         <Label Grid.Row="0" Grid.Column="2" Content="_2 Számlaszám" Target="{Binding ElementName=NumberBox}" VerticalAlignment="Center" Margin="2"/>
@@ -60,6 +70,8 @@
                   ItemsSource="{Binding PaymentMethods}"
                   SelectedItem="{Binding SelectedInvoice.PaymentMethod, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}"
                   DisplayMemberPath="Name"
+                  Validation.ErrorTemplate="{StaticResource RequiredTemplate}"
+                  ToolTip="Kötelező mező"
                   helpers:FocusBehavior.AdvanceOnEnter="True"/>
 
         <!-- Row 3 -->

--- a/Presentation/Views/ProductView.xaml
+++ b/Presentation/Views/ProductView.xaml
@@ -44,7 +44,25 @@
                   Margin="5"
                     PreviewKeyDown="DataGrid_PreviewKeyDown"
                   CellEditEnding="DataGrid_CellEditEnding">
+            <DataGrid.RowStyle>
+                <Style TargetType="DataGridRow">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsLocked}" Value="True">
+                            <Setter Property="IsEnabled" Value="False" />
+                            <Setter Property="Background" Value="#FFEFEFEF" />
+                            <Setter Property="ToolTip" Value="Termék lezárt" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
             <DataGrid.Columns>
+                <DataGridTemplateColumn Header="" Width="30">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="🔒" Visibility="{Binding IsLocked, Converter={StaticResource BoolToVisibilityConverter}}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" />
                 <DataGridTextColumn Header="Nettó"
                                     Binding="{Binding Net, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}, ValidatesOnNotifyDataErrors=True}"


### PR DESCRIPTION
## Summary
- mark products as locked in the domain model and DTO
- propagate locked flag through mappers and ProductService
- expose SelectedProductLocked property in ProductViewModel
- show lock icon and disable editing in ProductView when product is locked
- highlight mandatory supplier and payment method fields on invoice header

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da2ffd360832299e1e10696fa0961