### PR TITLE
Refactor invoice validation context

### DIFF
--- a/Application/Services/InvoiceService.cs
+++ b/Application/Services/InvoiceService.cs
@@ -150,12 +150,6 @@ namespace InvoiceApp.Application.Services
             }
         }
 
-        protected override async Task ValidateAsync(Invoice entity)
-        {
-            using var ctx = _repository.CreateContext();
-            await ValidateAsync(entity, ctx);
-        }
-
         private async Task ValidateAsync(Invoice entity, InvoiceContext ctx)
         {
             await _validator.ValidateAndThrowAsync(entity.ToDto());

--- a/InvoiceApp.Tests/InvoiceServiceTests.cs
+++ b/InvoiceApp.Tests/InvoiceServiceTests.cs
@@ -160,6 +160,38 @@ namespace InvoiceApp.Tests
 
             CollectionAssert.AreEquivalent(firstItemIds, savedItemIds);
         }
+
+        [TestMethod]
+        public async Task SaveAsync_Throws_WhenDateInFuture()
+        {
+            var factory = CreateFactory();
+            var repo = new EfInvoiceRepository(factory);
+            var changeRepo = new EfChangeLogRepository(factory);
+            var logService = new ChangeLogService(changeRepo);
+            var validator = new InvoiceDtoValidator();
+            var service = new InvoiceService(repo, logService, validator);
+
+            var invoice = CreateInvoice("INV-FUT");
+            invoice.Date = DateTime.Today.AddDays(1);
+
+            await Assert.ThrowsExceptionAsync<BusinessRuleViolationException>(() => service.SaveAsync(invoice));
+        }
+
+        [TestMethod]
+        public async Task SaveAsync_Throws_WhenNoItems()
+        {
+            var factory = CreateFactory();
+            var repo = new EfInvoiceRepository(factory);
+            var changeRepo = new EfChangeLogRepository(factory);
+            var logService = new ChangeLogService(changeRepo);
+            var validator = new InvoiceDtoValidator();
+            var service = new InvoiceService(repo, logService, validator);
+
+            var invoice = CreateInvoice("INV-EMPTY");
+            invoice.Items.Clear();
+
+            await Assert.ThrowsExceptionAsync<BusinessRuleViolationException>(() => service.SaveAsync(invoice));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure invoice validation uses the same DbContext instance as saving
- remove redundant ValidateAsync override
- cover invoice validation for future dates and empty item lists

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e1f264e748322ae56197a3dea9de8